### PR TITLE
Queries op geoviews maken geen gebruik meer van de spatial index

### DIFF
--- a/bag/db/script/adres-tabel.sql
+++ b/bag/db/script/adres-tabel.sql
@@ -25,11 +25,8 @@ CREATE TABLE adres (
     adresseerbaarobject numeric(16,0),
     nummeraanduiding numeric(16,0),
     nevenadres BOOLEAN DEFAULT FALSE,
-    geopunt geometry,
-    textsearchable_adres tsvector,
-    CONSTRAINT enforce_dims_punt CHECK ((st_ndims(geopunt) = 3)),
-    CONSTRAINT enforce_geotype_punt CHECK (((geometrytype(geopunt) = 'POINT'::text) OR (geopunt IS NULL))),
-    CONSTRAINT enforce_srid_punt CHECK ((st_srid(geopunt) = 28992))
+    geopunt geometry(PointZ, 28992),
+    textsearchable_adres tsvector
 );
 
 -- Insert (actuele+bestaande) data uit combinatie van BAG tabellen: Verblijfplaats

--- a/bag/db/script/bag-db.sql
+++ b/bag/db/script/bag-db.sql
@@ -58,16 +58,9 @@ CREATE TABLE woonplaats (
   woonplaatsNaam VARCHAR(80),
   woonplaatsStatus woonplaatsStatus,
   geom_valid BOOLEAN,
-  geovlak geometry,
-
-  CONSTRAINT enforce_dims_geometrie CHECK ((st_ndims(geovlak) = 2)),
-  CONSTRAINT enforce_geotype_geometrie CHECK (
-          ((geometrytype(geovlak) = 'MULTIPOLYGON'::text) OR (geovlak IS NULL))),
-  CONSTRAINT enforce_srid_geometrie CHECK ((st_srid(geovlak) = 28992)),
+  geovlak geometry(MultiPolygon, 28992),
   PRIMARY KEY (gid)
 ) WITH (OIDS=true);
--- werkt niet met PG schema
--- SELECT AddGeometryColumn('public', 'woonplaats', 'geovlak', 28992, 'MULTIPOLYGON', 2);
 
 DROP TABLE IF EXISTS openbareruimte CASCADE;
 DROP TYPE IF EXISTS openbareRuimteStatus;
@@ -137,15 +130,9 @@ CREATE TABLE ligplaats (
   hoofdadres NUMERIC(16),
   ligplaatsStatus ligplaatsStatus,
   geom_valid BOOLEAN,
-  geovlak geometry,
-  CONSTRAINT enforce_dims_geometrie CHECK ((st_ndims(geovlak) = 3)),
-  CONSTRAINT enforce_geotype_geometrie CHECK (
-          ((geometrytype(geovlak) = 'POLYGON'::text) OR (geovlak IS NULL))),
-  CONSTRAINT enforce_srid_geometrie CHECK ((st_srid(geovlak) = 28992)),
+  geovlak geometry(PolygonZ, 28992),
   PRIMARY KEY (gid)
 ) WITH (OIDS=true);
--- werkt niet met PG schema
--- SELECT AddGeometryColumn('public', 'ligplaats', 'geovlak', 28992, 'POLYGON', 3);
 
 DROP TABLE IF EXISTS standplaats CASCADE;
 DROP TYPE IF EXISTS standplaatsStatus;
@@ -164,15 +151,9 @@ CREATE TABLE standplaats (
   hoofdadres NUMERIC(16),
   standplaatsStatus standplaatsStatus,
   geom_valid BOOLEAN,
-  geovlak geometry,
-  CONSTRAINT enforce_dims_geometrie CHECK ((st_ndims(geovlak) = 3)),
-  CONSTRAINT enforce_geotype_geometrie CHECK (
-          ((geometrytype(geovlak) = 'POLYGON'::text) OR (geovlak IS NULL))),
-  CONSTRAINT enforce_srid_geometrie CHECK ((st_srid(geovlak) = 28992)),
+  geovlak geometry(PolygonZ, 28992),
   PRIMARY KEY (gid)
 ) WITH (OIDS=true);
--- werkt niet met PG schema
--- SELECT AddGeometryColumn('public', 'standplaats', 'geovlak', 28992, 'POLYGON', 3);
 
 DROP TABLE IF EXISTS verblijfsobject CASCADE;
 DROP TYPE IF EXISTS verblijfsobjectStatus;
@@ -192,23 +173,10 @@ CREATE TABLE verblijfsobject (
   verblijfsobjectStatus verblijfsobjectStatus,
   oppervlakteVerblijfsobject NUMERIC(6),
   geom_valid BOOLEAN,
-  geopunt geometry,
-  geovlak geometry,
-  CONSTRAINT enforce_dims_punt CHECK ((st_ndims(geopunt) = 3)),
-  CONSTRAINT enforce_geotype_punt CHECK (
-          ((geometrytype(geopunt) = 'POINT'::text) OR (geopunt IS NULL))),
-  CONSTRAINT enforce_srid_punt CHECK ((st_srid(geopunt) = 28992)),
-
-  CONSTRAINT enforce_dims_vlak CHECK ((st_ndims(geovlak) = 3)),
-  CONSTRAINT enforce_geotype_vlak CHECK (
-          ((geometrytype(geovlak) = 'POLYGON'::text) OR (geovlak IS NULL))),
-  CONSTRAINT enforce_srid_vlak CHECK ((st_srid(geovlak) = 28992)),
+  geopunt geometry(PointZ, 28992),
+  geovlak geometry(PolygonZ, 28992),
   PRIMARY KEY (gid)
 ) WITH (OIDS=true);
--- werkt niet met PG schema
--- SELECT AddGeometryColumn('public', 'verblijfsobject', 'geopunt', 28992, 'POINT', 3);
--- SELECT AddGeometryColumn('public', 'verblijfsobject', 'geovlak', 28992, 'POLYGON', 3);
--- UPDATE verblijfsobject SET geopunt = ST_Force_3D(ST_Centroid(geovlak)) WHERE geopunt is  null and geovlak is not null;
 
 DROP TABLE IF EXISTS pand CASCADE;
 DROP TYPE IF EXISTS pandStatus;
@@ -227,18 +195,11 @@ CREATE TABLE pand (
   pandStatus pandStatus,
   bouwjaar NUMERIC(4),
   geom_valid BOOLEAN,
-  geovlak geometry,
-  CONSTRAINT enforce_dims_geometrie CHECK ((st_ndims(geovlak) = 3)),
-  CONSTRAINT enforce_geotype_geometrie CHECK (
-          ((geometrytype(geovlak) = 'POLYGON'::text) OR (geovlak IS NULL))),
-  CONSTRAINT enforce_srid_geometrie CHECK ((st_srid(geovlak) = 28992)),
+  geovlak geometry(PolygonZ, 28992),
   PRIMARY KEY (gid)
 
 ) WITH (OIDS=true);
 -- UPDATE pand SET geom_valid = ST_IsValid(geovlak);
-
--- werkt niet met PG schema
--- SELECT AddGeometryColumn('public', 'pand', 'geovlak', 28992, 'POLYGON', 3);
 
 
 --

--- a/bag/db/script/bag-view-actueel-bestaand.sql
+++ b/bag/db/script/bag-view-actueel-bestaand.sql
@@ -16,7 +16,7 @@ CREATE VIEW ligplaatsactueel AS
             ligplaats.ligplaatsstatus,
             ligplaats.begindatumtijdvakgeldigheid,
             ligplaats.einddatumtijdvakgeldigheid,
-            ligplaats.geovlak::geometry(PolygonZ, 28992)
+            ligplaats.geovlak
     FROM ligplaats
     WHERE
       ligplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -38,7 +38,7 @@ CREATE VIEW ligplaatsactueelbestaand AS
             ligplaats.ligplaatsstatus,
             ligplaats.begindatumtijdvakgeldigheid,
             ligplaats.einddatumtijdvakgeldigheid,
-            ligplaats.geovlak::geometry(PolygonZ, 28992)
+            ligplaats.geovlak
     FROM ligplaats
     WHERE
       ligplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -164,7 +164,7 @@ CREATE VIEW pandactueel AS
             pand.bouwjaar,
             pand.begindatumtijdvakgeldigheid,
             pand.einddatumtijdvakgeldigheid,
-            pand.geovlak::geometry(PolygonZ, 28992)
+            pand.geovlak
     FROM pand
     WHERE
       pand.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -186,7 +186,7 @@ CREATE VIEW pandactueelbestaand AS
             pand.bouwjaar,
             pand.begindatumtijdvakgeldigheid,
             pand.einddatumtijdvakgeldigheid,
-            pand.geovlak::geometry(PolygonZ, 28992)
+            pand.geovlak
   FROM pand
    WHERE
      pand.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -211,7 +211,7 @@ CREATE VIEW standplaatsactueel AS
             standplaats.standplaatsstatus,
             standplaats.begindatumtijdvakgeldigheid,
             standplaats.einddatumtijdvakgeldigheid,
-            standplaats.geovlak::geometry(PolygonZ, 28992)
+            standplaats.geovlak
   FROM standplaats
   WHERE
     standplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -234,7 +234,7 @@ CREATE VIEW standplaatsactueelbestaand AS
             standplaats.standplaatsstatus,
             standplaats.begindatumtijdvakgeldigheid,
             standplaats.einddatumtijdvakgeldigheid,
-            standplaats.geovlak::geometry(PolygonZ, 28992)
+            standplaats.geovlak
   FROM standplaats
   WHERE
     standplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -259,8 +259,8 @@ CREATE VIEW verblijfsobjectactueel AS
             verblijfsobject.oppervlakteverblijfsobject,
             verblijfsobject.begindatumtijdvakgeldigheid,
             verblijfsobject.einddatumtijdvakgeldigheid,
-            verblijfsobject.geopunt::geometry(PointZ, 28992),
-            verblijfsobject.geovlak::geometry(PolygonZ, 28992)
+            verblijfsobject.geopunt,
+            verblijfsobject.geovlak
     FROM verblijfsobject
   WHERE
     verblijfsobject.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -284,8 +284,8 @@ CREATE VIEW verblijfsobjectactueelbestaand AS
             verblijfsobject.oppervlakteverblijfsobject,
             verblijfsobject.begindatumtijdvakgeldigheid,
             verblijfsobject.einddatumtijdvakgeldigheid,
-            verblijfsobject.geopunt::geometry(PointZ, 28992),
-            verblijfsobject.geovlak::geometry(PolygonZ, 28992)
+            verblijfsobject.geopunt,
+            verblijfsobject.geovlak
     FROM verblijfsobject
     WHERE
       verblijfsobject.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -313,7 +313,7 @@ CREATE VIEW woonplaatsactueel AS
             woonplaats.woonplaatsstatus,
             woonplaats.begindatumtijdvakgeldigheid,
             woonplaats.einddatumtijdvakgeldigheid,
-            woonplaats.geovlak::geometry(MultiPolygon, 28992)
+            woonplaats.geovlak
     FROM woonplaats
   WHERE
     woonplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP
@@ -335,7 +335,7 @@ CREATE VIEW woonplaatsactueelbestaand AS
             woonplaats.woonplaatsstatus,
             woonplaats.begindatumtijdvakgeldigheid,
             woonplaats.einddatumtijdvakgeldigheid,
-            woonplaats.geovlak::geometry(MultiPolygon, 28992)
+            woonplaats.geovlak
     FROM woonplaats
   WHERE
     woonplaats.begindatumtijdvakgeldigheid <= LOCALTIMESTAMP

--- a/bag/db/script/gemeente-provincie-tabel.sql
+++ b/bag/db/script/gemeente-provincie-tabel.sql
@@ -10,7 +10,7 @@
 drop table if exists gemeente;
 
 create table gemeente as
-  select gw.gemeentecode,gp.gemeentenaam,ST_Multi(ST_Union(w.geovlak)) as geovlak
+  select gw.gemeentecode,gp.gemeentenaam,ST_Multi(ST_Union(w.geovlak))::geometry(MultiPolygon, 28992) as geovlak
   from gemeente_woonplaatsactueelbestaand as gw, woonplaatsactueelbestaand as w, provincie_gemeenteactueelbestaand as gp
   where gw.woonplaatscode = w.identificatie and gw.gemeentecode = gp.gemeentecode
   group by gw.gemeentecode,gp.gemeentenaam;
@@ -27,7 +27,7 @@ CREATE INDEX gemeente_naam ON gemeente USING btree (gemeentenaam);
 drop table if exists provincie;
 
 create table provincie as
-  select provinciecode,provincienaam,ST_Multi(ST_Union(gemeente.geovlak)) as geovlak
+  select provinciecode,provincienaam,ST_Multi(ST_Union(gemeente.geovlak))::geometry(MultiPolygon, 28992) as geovlak
   from
   	provincie_gemeenteactueelbestaand,
   	gemeente


### PR DESCRIPTION
Geconstateerd door Matthijs Laan, a.d.h.v. recente dumps.
Zijn bericht is op 16-08 jl. naar de mailinglijst verstuurd.

> Sinds de dump van juli van http://data.nlextract.nl/bag/postgis/bag-laatst.backup staat er in de views een cast van de geo kolom, bijvoorbeeld:
> 
> CREATE OR REPLACE VIEW bag20160812.pandactueel AS 
>  SELECT pand.gid,
> ...
>     pand.geovlak::geometry(PolygonZ,28992) AS geovlak
> 
> Dit zorgt ervoor dat een query als onderstaand op de view niet de index gebruikt maar een sequentiele scan:
> 
> explain SELECT count("geovlak") FROM "bag20160812"."pandactueel" WHERE  "geovlak" && ST_GeomFromText('POLYGON ((148547.96 415797.87999999995, 148547.96 415907.08, 148657.16 415907.08, 148657.16 415797.87999999995, 148547.96 415797.87999999995))', 28992);
>  Aggregate  (cost=1129666.10..1129666.11 rows=1 width=252)
>    ->  Seq Scan on pand  (cost=0.00..1119191.27 rows=2094967 width=252)
>          Filter: ((NOT aanduidingrecordinactief) AND geom_valid AND ((geovlak)::geometry(PolygonZ,28992) && '0103000020407100000100000005000000E17A14AE1F22024151B81E85D7601941E17A14AE1F2202411F85EB518C6219417B14AE47892502411F85EB518C6219417B14AE478925024151B81E85D7601941E17A14AE1F22024151B81E85D7601941'::geometry) AND (begindatumtijdvakgeldigheid <= ('now'::cstring)::timestamp without time zone) AND ((einddatumtijdvakgeldigheid IS NULL) OR (einddatumtijdvakgeldigheid >= ('now'::cstring)::timestamp without time zone)))
> 
> Direct een query op de pand tabel met de WHERE uit pandactueel gebruikt wel de index:
> 
> explain SELECT count("geovlak") FROM "bag20160812"."pand" WHERE  "geovlak" && ST_GeomFromText('POLYGON ((148547.96 415797.87999999995, 148547.96 415907.08, 148657.16 415907.08, 148657.16 415797.87999999995, 148547.96 415797.87999999995))', 28992) and pand.begindatumtijdvakgeldigheid <= 'now'::text::timestamp without time zone AND (pand.einddatumtijdvakgeldigheid IS NULL OR pand.einddatumtijdvakgeldigheid >= 'now'::text::timestamp without time zone) AND pand.aanduidingrecordinactief = false AND pand.geom_valid = true;
>  Aggregate  (cost=36.69..36.70 rows=1 width=252)
>    ->  Index Scan using pand_geom_idx on pand  (cost=0.42..36.68 rows=6 width=252)
>          Index Cond: (geovlak && '0103000020407100000100000005000000E17A14AE1F22024151B81E85D7601941E17A14AE1F2202411F85EB518C6219417B14AE47892502411F85EB518C6219417B14AE478925024151B81E85D7601941E17A14AE1F22024151B81E85D7601941'::geometry)
>          Filter: ((NOT aanduidingrecordinactief) AND geom_valid AND (begindatumtijdvakgeldigheid <= ('now'::cstring)::timestamp without time zone) AND ((einddatumtijdvakgeldigheid IS NULL) OR (einddatumtijdvakgeldigheid >= ('now'::cstring)::timestamp without time zone)))
> 
> Als ik de view opnieuw maak en de cast van geovlak naar PolygonZ verwijder wordt wel weer de index gebruikt. Het lijkt me niet handig om deze casts in de views te hebben. 

@justb4: jij hebt al een review gedaan en Matthijs heeft op 22-08 gemeld dat het bij hem werkt. Ik zou de merge zelf kunnen doen, maar proceduretechnisch vind ik dat niet correct. Bvd.