### PR TITLE
When INSERTing, use NULL when parent doesn't have specified field

### DIFF
--- a/bag/src/bagattribuut.py
+++ b/bag/src/bagattribuut.py
@@ -622,7 +622,7 @@ class BAGrelatieAttribuut(BAGattribuut):
                 if self._parent.heeftAttribuut(attr):
                     inhoud.append(self._parent.attribuut(attr).waardeSQL())
                 else:
-                    inhoud.append('')
+                    inhoud.append(None)
             inhoud.append(waarde)
             self.inhoud.append(tuple(inhoud))
 


### PR DESCRIPTION
This is "adresseerbaarobjectnevenadres" has 3 fields, only one of which
will be present in the _parent object (ligplaatsstatus, standplaatsstatus
or verblijfplaatsstatus).

Because the database uses enum types for these values, and those enums
don't contain the empty string, inserting these records breaks.

By inserting NULLs instead, everything works the same as when using the
"COPY" statement.

This is a fix for #251 