### PR TITLE
Vervang referenties aan http://www.nlextract/file-cabinet (link rot)

### DIFF
--- a/VERSIES
+++ b/VERSIES
@@ -1,5 +1,5 @@
 Dit bestand bevat versie informatie voor NLExtract. Versies en snapshots zijn te downloaden
-via de link: https://github.com/nlextract/NLExtract/releases. Nieuwste bovenaan.
+via de link: https://github.com/nlextract/NLExtract/releases. De nieuwste versie staat bovenaan: kies de "real-release" nlextract zip.
 De rest ligt nog open afhankelijk van wensen gebruikers en natuurlijk eventuele bugs.
 
 ONGEPLAND

--- a/VERSIES
+++ b/VERSIES
@@ -1,5 +1,5 @@
 Dit bestand bevat versie informatie voor NLExtract. Versies en snapshots zijn te downloaden
-via de link: http://www.nlextract.nl/file-cabinet. Nieuwste bovenaan.
+via de link: https://github.com/nlextract/NLExtract/releases. Nieuwste bovenaan.
 De rest ligt nog open afhankelijk van wensen gebruikers en natuurlijk eventuele bugs.
 
 ONGEPLAND

--- a/bag/README
+++ b/bag/README
@@ -3,7 +3,7 @@ bag-extract is onderdeel van de NLExtract tools voor het inlezen en verrijken va
 
 De BAG Leveringsbestanden (totaal plm 1.2 GB .zip) worden iedere maand ververst en zijn te downloaden via deze  
 link: http://geodata.nationaalgeoregister.nl/inspireadressen/atom/inspireadressen.xml (Atom feed).
-Als je wilt testen met een kleiner bestand kun je via http://www.nlextract.nl/file-cabinet
+Als je wilt testen met een kleiner bestand kun je via https://data.nlextract.nl/bag/bron/BAG_Amstelveen_2011feb01.zip
 ook de "BAG Amstelveen" (5.6 MB) downloaden.
 
 bag-extract biedt de volgende functionaliteiten:

--- a/doc/source/bagextract.rst
+++ b/doc/source/bagextract.rst
@@ -18,7 +18,7 @@ BAG downloaden
 
 De BAG Leveringsbestanden (totaal plm 1.5 GB .zip) worden iedere maand ververst en zijn te downloaden via deze
 PDOK link: http://geodata.nationaalgeoregister.nl/inspireadressen/atom/inspireadressen.xml (Atom feed).
-Als je wilt testen met een kleiner bestand kun je via http://www.nlextract.nl/file-cabinet
+Als je wilt testen met een kleiner bestand kun je via https://data.nlextract.nl/bag/bron/BAG_Amstelveen_2011feb01.zip
 ook de "BAG Amstelveen" (5.6 MB) downloaden. Let wel dat de bestandsstructuur van de Amstelveen-levering afwijkt van de tegenwoordige BAG-leveringen.
 
 BAG PostGIS dumps downloaden
@@ -47,7 +47,7 @@ Bag-extract biedt de volgende functionaliteiten:
 Bag-extract downloaden
 ----------------------
 
-- download NLExtract, zie laatste versie op: http://www.nlextract.nl/file-cabinet
+- download NLExtract, zie laatste versie op: https://github.com/nlextract/NLExtract/releases
 - of snapshot (huidige repo versie) via git: git clone http://github.com/opengeogroep/NLExtract.git
 - of snapshot als .zip: https://github.com/nlextract/NLExtract/zipball/master
 

--- a/doc/source/bagextract.rst
+++ b/doc/source/bagextract.rst
@@ -47,7 +47,7 @@ Bag-extract biedt de volgende functionaliteiten:
 Bag-extract downloaden
 ----------------------
 
-- download NLExtract, zie laatste versie op: https://github.com/nlextract/NLExtract/releases
+- download NLExtract, zie laatste versie op: https://github.com/nlextract/NLExtract/releases. De nieuwste versie staat bovenaan: kies de "real-release" nl  extract zip.
 - of snapshot (huidige repo versie) via git: git clone http://github.com/opengeogroep/NLExtract.git
 - of snapshot als .zip: https://github.com/nlextract/NLExtract/zipball/master
 

--- a/doc/source/bgtextract.rst
+++ b/doc/source/bgtextract.rst
@@ -47,7 +47,7 @@ Als je heel Nederland wilt inlezen, kun je het beste het bestand exclusief plaat
 Bgt-extract downloaden
 ----------------------
 
-Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases. De nieuwste versie staat bovenaan: kies de "real-release" nlextract zip.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:

--- a/doc/source/bgtextract.rst
+++ b/doc/source/bgtextract.rst
@@ -47,7 +47,7 @@ Als je heel Nederland wilt inlezen, kun je het beste het bestand exclusief plaat
 Bgt-extract downloaden
 ----------------------
 
-Vind altijd de laatste versie op: http://www.nlextract.nl/file-cabinet.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:

--- a/doc/source/brkextract.rst
+++ b/doc/source/brkextract.rst
@@ -36,7 +36,7 @@ De BRK wordt via PDOK geleverd in ZIP-bestanden. Deze worden per provincie besch
 Brk-extract downloaden
 ----------------------
 
-Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases. De nieuwste versie staat bovenaan: kies de "real-release" nlextract zip.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:

--- a/doc/source/brkextract.rst
+++ b/doc/source/brkextract.rst
@@ -36,7 +36,7 @@ De BRK wordt via PDOK geleverd in ZIP-bestanden. Deze worden per provincie besch
 Brk-extract downloaden
 ----------------------
 
-Vind altijd de laatste versie op: http://www.nlextract.nl/file-cabinet.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:

--- a/doc/source/top10extract.rst
+++ b/doc/source/top10extract.rst
@@ -60,7 +60,7 @@ gebruik dan een oude release van NLExtract.
 Top10-extract downloaden
 ------------------------
 
-Vind altijd de laatste versie op: http://www.nlextract.nl/file-cabinet.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:

--- a/doc/source/top10extract.rst
+++ b/doc/source/top10extract.rst
@@ -60,7 +60,7 @@ gebruik dan een oude release van NLExtract.
 Top10-extract downloaden
 ------------------------
 
-Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases.
+Vind altijd de laatste versie op: https://github.com/nlextract/NLExtract/releases. De nieuwste versie staat bovenaan: kies de "real-release" nlextract zip.
 
 Omdat NLExtract voortdurend in ontwikkeling is, kun je ook de actuele broncode, een `snapshot`, downloaden
 en op dezelfde manier gebruiken als een versie:


### PR DESCRIPTION
Vervangt alle verwijzingen in de master branch van `http://www.nlextract.nl/file-cabinet` naar werkende, relevante links