### PR TITLE
Switch to Python 3

### DIFF
--- a/bag/bin/bag-extract.sh
+++ b/bag/bin/bag-extract.sh
@@ -19,8 +19,8 @@ PY_SCRIPT=$BASEDIR/src/bagextract.py
 # uitvoeren Python script met alle meegegeven args
 ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
 if [ $ret -eq 0 ]; then
-    #Python 3 is de standaard, roep python2 aan.
-    python2 $PY_SCRIPT $@
-else
+    #Python 3 is de standaard, roep python aan.
     python $PY_SCRIPT $@
+else
+    python3 $PY_SCRIPT $@
 fi

--- a/bag/bin/gemeentelijke-indeling.sh
+++ b/bag/bin/gemeentelijke-indeling.sh
@@ -19,8 +19,8 @@ PY_SCRIPT=$BASEDIR/src/gemeentelijke-indeling.py
 # uitvoeren Python script met alle meegegeven args
 ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
 if [ $ret -eq 0 ]; then
-    #Python 3 is de standaard, roep python2 aan.
-    python2 $PY_SCRIPT "$@"
-else
+    #Python 3 is de standaard, roep python aan.
     python $PY_SCRIPT "$@"
+else
+    python3 $PY_SCRIPT "$@"
 fi

--- a/bag/src/bagattribuut.py
+++ b/bag/src/bagattribuut.py
@@ -134,7 +134,7 @@ class BAGattribuut:
 
     # Print informatie over het attribuut op het scherm
     def schrijf(self):
-        print "- %-27s: %s" % (self._naam, self._waarde)
+        print("- %-27s: %s" % (self._naam, self._waarde))
 
 
 # --------------------------------------------------------------------------------------------------------
@@ -159,7 +159,7 @@ class BAGstringAttribuut(BAGattribuut):
             # Voor string kolommen (default) willen we NULL, geen lege string
             waarde = None
         if waarde is not None:
-            # print "voor:"+ self._waarde
+            # print("voor:" + self._waarde)
             waarde = waarde.strip()
             # Kan voorkomen dat strings langer zijn in BAG
             # ondanks restrictie vanuit BAG XSD model
@@ -698,10 +698,10 @@ class BAGrelatieAttribuut(BAGattribuut):
         first = True
         for waarde in self._waarde:
             if first:
-                print "- %-27s: %s" % (self.naam(), waarde)
+                print("- %-27s: %s" % (self.naam(), waarde))
                 first = False
             else:
-                print "- %-27s  %s" % ("", waarde)
+                print("- %-27s  %s" % ("", waarde))
 
 
 # --------------------------------------------------------------------------------------------------------

--- a/bag/src/bagattribuut.py
+++ b/bag/src/bagattribuut.py
@@ -454,13 +454,13 @@ class BAGpoint(BAGgeoAttribuut):
                 gmlNode = xmlGeometrie.find('./' + tagVolledigeNS("gml:Point", xml.nsmap))
                 if gmlNode is not None:
                     gmlStr = etree.tostring(gmlNode)
-                    self._geometrie = ogr.CreateGeometryFromGML(str(gmlStr))
+                    self._geometrie = ogr.CreateGeometryFromGML(gmlStr.decode())
                 else:
                     # Forceer punt uit Polygoon
                     gmlNode = xmlGeometrie.find('./' + tagVolledigeNS("gml:Polygon", xml.nsmap))
                     if gmlNode is not None:
                         gmlStr = etree.tostring(gmlNode)
-                        self._geometrie = ogr.CreateGeometryFromGML(str(gmlStr))
+                        self._geometrie = ogr.CreateGeometryFromGML(gmlStr.decode())
                         self._geometrie = self._geometrie.Centroid()
         except Exception:
             Log.log.error("ik kan hier echt geen POINT van maken: %s (en zet dit op 0,0,0)" % str(point.text))
@@ -485,7 +485,7 @@ class BAGpolygoon(BAGgeoAttribuut):
             gmlNode = xmlGeometrie.find('./' + tagVolledigeNS("gml:Polygon", xmlGeometrie.nsmap))
             if gmlNode is not None:
                 gmlStr = etree.tostring(gmlNode)
-                self._geometrie = ogr.CreateGeometryFromGML(str(gmlStr))
+                self._geometrie = ogr.CreateGeometryFromGML(gmlStr.decode())
 
 
 # --------------------------------------------------------------------------------------------------------
@@ -511,14 +511,14 @@ class BAGmultiPolygoon(BAGpolygoon):
                 gmlNode = xmlGeometrie.find('./' + tagVolledigeNS("gml:Polygon", xml.nsmap))
                 if gmlNode is not None:
                     gmlStr = etree.tostring(gmlNode)
-                    polygon = ogr.CreateGeometryFromGML(str(gmlStr))
+                    polygon = ogr.CreateGeometryFromGML(gmlStr.decode())
                     self._geometrie = ogr.Geometry(ogr.wkbMultiPolygon)
                     self._geometrie.AddGeometryDirectly(polygon)
 
             else:
                 # MultiSurface
                 gmlStr = etree.tostring(gmlNode)
-                self._geometrie = ogr.CreateGeometryFromGML(str(gmlStr))
+                self._geometrie = ogr.CreateGeometryFromGML(gmlStr.decode())
                 if self._geometrie is None:
                     Log.log.warn("Null MultiSurface in BAGmultiPolygoon: tag=%s parent=%s" % (
                         self._tag, self._parentObj.identificatie()))

--- a/bag/src/bagattribuut.py
+++ b/bag/src/bagattribuut.py
@@ -646,7 +646,7 @@ class BAGrelatieAttribuut(BAGattribuut):
             # Einddatum kan leeg zijn : TODO vang dit op in waardeSQL()
             einddatumWaardeSQL = self._parent.attribuut('einddatumTijdvakGeldigheid').waardeSQL()
             if not einddatumWaardeSQL or einddatumWaardeSQL is '':
-                einddatumWaardeSQL = '\\\N'
+                einddatumWaardeSQL = r'\N'
             self.sql += einddatumWaardeSQL + "~"
 
             for attr in self._extraAttributes:
@@ -657,11 +657,11 @@ class BAGrelatieAttribuut(BAGattribuut):
                     attrWaarde = ''
 
                 if not attrWaarde or attrWaarde is '':
-                    attrWaarde = '\\\N'
+                    attrWaarde = r'\N'
                 self.sql += attrWaarde + "~"
 
             if not waarde:
-                waarde = '\\\N'
+                waarde = r'\N'
             self.sql += waarde + "\n"
 
     # Maak update SQL voor deze relatie

--- a/bag/src/bagattribuut.py
+++ b/bag/src/bagattribuut.py
@@ -17,9 +17,9 @@ from etree import etree, tagVolledigeNS
 import sys
 
 try:
-    from osgeo import ogr  # apt-get install python-gdal
+    from osgeo import ogr  # apt-get install python3-gdal
 except ImportError:
-    print("FATAAL: GDAL Python bindings zijn niet beschikbaar, installeer bijv met 'apt-get install python-gdal'")
+    print("FATAAL: GDAL Python bindings zijn niet beschikbaar, installeer bijv met 'apt-get install python3-gdal'")
     sys.exit(-1)
 
 

--- a/bag/src/bagconfig.py
+++ b/bag/src/bagconfig.py
@@ -11,7 +11,7 @@
 import sys
 import os
 
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from log import Log
 
 

--- a/bag/src/bagdownloadgui.py
+++ b/bag/src/bagdownloadgui.py
@@ -192,8 +192,8 @@ class BAGDownloadPanel(scrolled.ScrolledPanel):
 
             # start thread
             DownloadThread(url, fsize, local_path)
-        except Exception, e:
-            print "Error: ", e
+        except Exception as e:
+            print("Error: ", e)
 
     # ----------------------------------------------------------------------
     def onDownloadUpdate(self, msg):

--- a/bag/src/bagextract.py
+++ b/bag/src/bagextract.py
@@ -15,13 +15,6 @@ from log import Log
 from bagconfig import BAGConfig
 
 
-# Nodig om output naar console/file van strings goed te krijgen
-# http://www.saltycrane.com/blog/2008/11/python-unicodeencodeerror-ascii-codec-cant-encode-character/
-# anders bijv. deze fout: 'ascii' codec can't encode character u'\xbf' in position 42: ordinal not in range(128)
-reload(sys)
-sys.setdefaultencoding("utf-8")
-
-
 class ArgParser(argparse.ArgumentParser):
     def error(self, message):
         print(message)

--- a/bag/src/bagextract.py
+++ b/bag/src/bagextract.py
@@ -49,7 +49,7 @@ def confirm(prompt=None, resp=False):
         prompt = '%s ([%s]/%s): ' % (prompt, 'N', 'j')
 
     while True:
-        ans = raw_input(prompt)
+        ans = input(prompt)
         if not ans:
             return resp
         if ans not in ['j', 'J', 'n', 'N']:

--- a/bag/src/bagextract.py
+++ b/bag/src/bagextract.py
@@ -24,7 +24,7 @@ sys.setdefaultencoding("utf-8")
 
 class ArgParser(argparse.ArgumentParser):
     def error(self, message):
-        print (message)
+        print(message)
         self.print_help()
         sys.exit(2)
 
@@ -60,7 +60,7 @@ def confirm(prompt=None, resp=False):
         if not ans:
             return resp
         if ans not in ['j', 'J', 'n', 'N']:
-            print ('Geef j of n.')
+            print('Geef j of n.')
             continue
         if ans == 'j' or ans == 'J':
             return True
@@ -164,7 +164,7 @@ def main():
         bagObjecten.append(Pand())
 
         for bagObject in bagObjecten:
-            print (bagObject.maakTabel())
+            print(bagObject.maakTabel())
         # Print end time
         Log.log.time("End")
 

--- a/bag/src/bagfilereader.py
+++ b/bag/src/bagfilereader.py
@@ -10,7 +10,7 @@ import os
 import zipfile
 import csv
 from etree import etree
-from io import StringIO
+from io import BytesIO
 from log import Log
 from processor import Processor
 from postgresdb import Database
@@ -95,7 +95,7 @@ class BAGFileReader:
         if len(filenaam_arr) > 1:
             ext = filenaam_arr[-1].lower()
 
-        # file_buf kan StringIO (stream/buffer) zijn uit zipfile
+        # file_buf kan BytesIO (stream/buffer) zijn uit zipfile
         file_resource = file_path
         if file_buf:
             file_resource = file_buf
@@ -155,6 +155,6 @@ class BAGFileReader:
 
         # Loop door op naam (datum) gesorteerde bestanden (m.n. i.v.m. mutatie-volgorde)
         for naam in sorted(zip_file.namelist(), key=fname_key):
-            self.process_file(naam, StringIO(zip_file.read(naam)))
+            self.process_file(naam, BytesIO(zip_file.read(naam)))
 
         self.database.log_actie('verwerkt', filenaam, 'verwerkt OK')

--- a/bag/src/bagfilereader.py
+++ b/bag/src/bagfilereader.py
@@ -123,7 +123,7 @@ class BAGFileReader:
             parsed_xml = etree.parse(file_resource)
             bericht = Log.log.endTimer("parseXML")
             self.database.log_actie('xml_parse', filenaam, bericht)
-        except (Exception), e:
+        except (Exception) as e:
             bericht = Log.log.error("fout %s in XML parsen, bestand=%s" % (str(e), filenaam))
             self.database.log_actie('xml_parse', filenaam, bericht, True)
             return
@@ -132,7 +132,7 @@ class BAGFileReader:
             try:
                 self.processor.processGemeentelijkeIndeling(parsed_xml.getroot(), filenaam)
                 self.database.log_actie('xml_processing', filenaam, 'verwerkt OK')
-            except (Exception), e:
+            except (Exception) as e:
                 bericht = Log.log.error("fout %s in XML DOM processing, bestand=%s" % (str(e), filenaam))
                 self.database.log_actie('xml_processing', filenaam, bericht, True)
         else:
@@ -140,7 +140,7 @@ class BAGFileReader:
                 # Verwerken parsed xml: de Processor bepaalt of het een extract of een mutatie is
                 self.processor.processDOM(parsed_xml.getroot(), filenaam)
                 self.database.log_actie('verwerkt', filenaam, 'verwerkt OK')
-            except (Exception), e:
+            except (Exception) as e:
                 bericht = Log.log.error("fout %s in XML DOM processing, bestand=%s" % (str(e), filenaam))
                 self.database.log_actie('xml_processing', filenaam, bericht, True)
 

--- a/bag/src/bagfilereader.py
+++ b/bag/src/bagfilereader.py
@@ -10,14 +10,10 @@ import os
 import zipfile
 import csv
 from etree import etree
+from io import StringIO
 from log import Log
 from processor import Processor
 from postgresdb import Database
-
-try:
-    from cStringIO import StringIO
-except Exception:
-    from StringIO import StringIO
 
 
 def fname_key(filenaam):

--- a/bag/src/bagobject.py
+++ b/bag/src/bagobject.py
@@ -167,7 +167,7 @@ class BAGObject:
             w = attribuut.waardeSQL()
             if not w:
                 # NULL value
-                w = '\\\N'
+                w = r'\N'
 
             # if attribuut.naam() == 'geom_valid':
             #   w = repr(False)

--- a/bag/src/bagobject.py
+++ b/bag/src/bagobject.py
@@ -151,7 +151,7 @@ class BAGObject:
 
     # Print informatie over het object op het scherm
     def schrijf(self):
-        print "*** %s ***" % (self.naam())
+        print("*** %s ***" % (self.naam()))
         for attribuut in self.attributen_volgorde:
             attribuut.schrijf()
         for relatie in self.relaties:

--- a/bag/src/bestuurlijkobject.py
+++ b/bag/src/bestuurlijkobject.py
@@ -80,7 +80,7 @@ class GemeenteWoonplaats(BestuurlijkObject):
         record.extend(emptylist)
         # Stel de lengte van het record object in op 12
         if record[0]:
-            # print record
+            # print(record)
             self.tag = "gem_LVC:GemeenteWoonplaats"
             self.naam = "gemeente_woonplaats"
             self.type = 'G_W'

--- a/bag/src/configeditorgui.py
+++ b/bag/src/configeditorgui.py
@@ -54,4 +54,4 @@ class ConfigEditorPanel(wx.Dialog):
         BAGConfig.config.user = props['Database user']
         BAGConfig.config.port = props['Database poort']
         BAGConfig.config.save()
-        print str(props)
+        print(str(props))

--- a/bag/src/gemeentelijke-indeling.py
+++ b/bag/src/gemeentelijke-indeling.py
@@ -74,7 +74,7 @@ def parse_gemeentelijke_indeling(args):
     try:
         # XML doc parsen naar etree object
         parsed_xml = etree.parse(args.input)
-    except (Exception), e:
+    except (Exception) as e:
         print("Error: Failed to parse file: %s (%s)" % (args.input, str(e)))
         return
 

--- a/bag/src/gemeentelijke-indeling.py
+++ b/bag/src/gemeentelijke-indeling.py
@@ -4,7 +4,7 @@
 #
 # Required dependencies (Debian/Ubuntu):
 #
-#  python-excelerator python-lxml
+#  python3-excelerator python3-lxml
 #
 # Required dependencies (PyPi):
 #

--- a/bag/src/gemeentelijke-indeling.py
+++ b/bag/src/gemeentelijke-indeling.py
@@ -43,12 +43,6 @@ import pyExcelerator
 from collections import defaultdict
 from etree import etree, stripschema
 
-# Nodig om output naar console/file van strings goed te krijgen
-# http://www.saltycrane.com/blog/2008/11/python-unicodeencodeerror-ascii-codec-cant-encode-character/
-# anders bijv. deze fout: 'ascii' codec can't encode character u'\xbf' in position 42: ordinal not in range(128)
-reload(sys)
-sys.setdefaultencoding("utf-8")
-
 
 class ArgParser(argparse.ArgumentParser):
     def error(self, message):

--- a/bag/src/geocode/GeoCode-pc-hn-ext.py
+++ b/bag/src/geocode/GeoCode-pc-hn-ext.py
@@ -16,16 +16,16 @@ sys.setdefaultencoding('ISO-8859-1')
 if len(sys.argv) == 1: sys.argv[1:] = ["-h"]
 
 if sys.argv[1] == "-h":
-    print 'Usage: '+os.path.basename(sys.argv[0])+' <input file name> <input adres name>'
-    print 'Input format: postcode;huisnummer;toevoeging;<extra data columns>'
-    print 'Input File format: signed UTF-8 (With BOM), can be changed by editing this script @ line 32'
-    print 'The <extra data columns> are added to the signed UTF-8 output file after the BAG data columns'
-    print '<input adres name> to rename the \'Input adres\' column. \'Input\' is replaced with the given name'
-    print 'Example: GeoCode-pc-hn-ext.py Postcodelijst-KPN.csv KANVAS  to geocode the KPN KANVAS list'
+    print('Usage: '+os.path.basename(sys.argv[0])+' <input file name> <input adres name>')
+    print('Input format: postcode;huisnummer;toevoeging;<extra data columns>')
+    print('Input File format: signed UTF-8 (With BOM), can be changed by editing this script @ line 32')
+    print('The <extra data columns> are added to the signed UTF-8 output file after the BAG data columns')
+    print('<input adres name> to rename the \'Input adres\' column. \'Input\' is replaced with the given name')
+    print('Example: GeoCode-pc-hn-ext.py Postcodelijst-KPN.csv KANVAS  to geocode the KPN KANVAS list')
     sys.exit(0)
 
 InputFile = sys.argv[1].rstrip('.csv')+'.csv'
-print 'InputFile =', InputFile
+print('InputFile =', InputFile)
 
 # Input CSV with postcode;huisnummer;toevoeging;<extra data columns>
 # encoding = utf-8-sig, utf8, ISO-8859-1, windows-1252
@@ -34,30 +34,30 @@ SIDReader = csv.reader(SIDFile,delimiter=';')
 
 # Output file name
 OutputFile = InputFile.rstrip('.csv')+'-geocoded.csv'
-print 'OutputFile =', OutputFile
+print('OutputFile =', OutputFile)
 
 if len(sys.argv)>2:
     InAdres = sys.argv[2]+' adres'
 else:
     InAdres = 'Input adres'
-print 'Input adres name =', InAdres
+print('Input adres name =', InAdres)
 
 header=next(SIDReader) # Read first line
 ncol=len(header) # Count columns
-#print 'Number of columns = ', ncol
-#print 'Header = ', header
+#print('Number of columns = ', ncol)
+#print('Header = ', header)
 
 if ncol<3:
-    print 'Only', ncol, 'columns in input file! Minimum is: postcode;huisnummer;toevoeging'
+    print('Only', ncol, 'columns in input file! Minimum is: postcode;huisnummer;toevoeging')
     sys.exit(2)
 else:
-    print 'Adding', (ncol-3), 'columns to output file'
+    print('Adding', (ncol-3), 'columns to output file')
 
 SID = list(SIDReader)
 rowcount = 0
 uid = 1
 row_count = sum(1 for row in SID) #Count rows
-#print 'Number of rows = ', row_count
+#print('Number of rows = ', row_count)
 
 # Column Selection from database
 SEL = "nummeraanduiding, adresseerbaarobject, pandid, pandstatus, pandbouwjaar, openbareruimtenaam, postcode, huisnummer, huisletter, huisnummertoevoeging, woonplaatsnaam, gemeentenaam, provincienaam, verblijfsobjectgebruiksdoel, oppervlakteverblijfsobject, verblijfsobjectstatus, typeadresseerbaarobject, nevenadres, st_x(ST_transform(geopunt, 4326)), st_y(ST_transform(geopunt, 4326)), st_x(geopunt), st_y(geopunt)"
@@ -85,12 +85,12 @@ for row in SID:
     req = req.strip()
     mult = ''
 
-    #print 'Requested Postcode =', req
-    print 'Progress = ', ((uid*100)/row_count), '%\r',
+    #print('Requested Postcode =', req)
+    print('Progress = ', ((uid*100)/row_count), '%\r',)
     rowcount += 1
 
     if pc == '':
-        print 'Line',rowcount+1,'without Postcode found! skipping!\n'
+        print('Line',rowcount+1,'without Postcode found! skipping!\n')
         uid += 1
         continue
 
@@ -106,67 +106,67 @@ for row in SID:
         ht = row[2]
         hl = ''
 
-    #print 'Postcode =', pc, "huisnummer", hn, "toevoeging", tv, "gesplitst in huisletter", hl, " en huisnummertoevoeging", ht
+    #print('Postcode =', pc, "huisnummer", hn, "toevoeging", tv, "gesplitst in huisletter", hl, " en huisnummertoevoeging", ht)
 
 
     if hl == "" and ht == "":
-        #print "PC+HN"
+        #print("PC+HN")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1],))
     elif hl == "":
-        #print "PC+HN+ht"
+        #print("PC+HN+ht")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LOWER(huisnummertoevoeging) = LOWER(%s) AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], ht,))
     elif ht == "":
-        #print "PC+HN+HL"
+        #print("PC+HN+HL")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND huisnummertoevoeging IS NULL AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], hl,))
     else:
-        #print "PC+HN+HL+ht"
+        #print("PC+HN+HL+ht")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND LOWER(huisnummertoevoeging) = LOWER(%s) AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], hl, ht,))
 
     rows = cur.fetchall()
 
     if cur.rowcount < 1 and not hl == '':
-        #print "No location found Trying PC+HN+(hl as ht)"
+        #print("No location found Trying PC+HN+(hl as ht)")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LOWER(huisnummertoevoeging) = LOWER(%s) AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], hl,))
         rows = cur.fetchall()
 
 #    if cur.rowcount < 1 :
-#        #print "No location found Trying PC+HN only"
+#        #print("No location found Trying PC+HN only")
 #        cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1],))
 #        rows = cur.fetchall()
 
     if cur.rowcount < 1 :
-        #print "No location found, trying not existing VBO!\n"
+        #print("No location found, trying not existing VBO!\n")
 
 
         if hl == "" and ht == "":
-            #print "PC+HN"
+            #print("PC+HN")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL", (AsIs(SEL), row[0], row[1],))
         elif hl == "":
-            #print "PC+HN+ht"
+            #print("PC+HN+ht")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LOWER(huisnummertoevoeging) = LOWER(%s)", (AsIs(SEL), row[0], row[1], ht,))
         elif ht == "":
-            #print "PC+HN+HL"
+            #print("PC+HN+HL")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND huisnummertoevoeging IS NULL", (AsIs(SEL), row[0], row[1], hl,))
         else:
-            #print "PC+HN+HL+ht"
+            #print("PC+HN+HL+ht")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND LOWER(huisnummertoevoeging) = LOWER(%s)", (AsIs(SEL), row[0], row[1], hl, ht,))
     
         rows = cur.fetchall()
     
         if cur.rowcount < 1 and not hl == '':
-            #print "No location found Trying PC+HN+(hl as ht)"
+            #print("No location found Trying PC+HN+(hl as ht)")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LOWER(huisnummertoevoeging) = LOWER(%s)", (AsIs(SEL), row[0], row[1], hl,))
             rows = cur.fetchall()
     
         if cur.rowcount < 1 :
-            #print "No location found Trying PC+HN only"
+            #print("No location found Trying PC+HN only")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL", (AsIs(SEL), row[0], row[1],))
             rows = cur.fetchall()
     
-    #print "number of location(s)", cur.rowcount, "\n"
+    #print("number of location(s)", cur.rowcount, "\n")
 
     if cur.rowcount < 1 :
-        #print "No location found!\n"
+        #print("No location found!\n")
         with io.open(OutputFile, 'a', encoding='utf-8-sig') as logfile:
             logfile.write(u"%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s" % (uid,req,'','','','','','Actueel BAG adres onbekend','','','','','','','','','','','','',0,0,0,0,mult))
             for item in range(ncol-3):
@@ -181,8 +181,8 @@ for row in SID:
     if cur.rowcount > 1 :
         row_count += (cur.rowcount-1)
         mult = str(cur.rowcount)+' VBO\'s op 1 adres'
-        #print "More than one object found in BAG database!"
-        #print 'Requested Postcode =', pc, "huisnummer", hn, "huisnummertoevoeging", tv, "\n"
+        #print("More than one object found in BAG database!")
+        #print('Requested Postcode =', pc, "huisnummer", hn, "huisnummertoevoeging", tv, "\n")
     else:
         mult = ''
 
@@ -210,25 +210,25 @@ for row in SID:
         rd_x = "{:.3f}".format(Decimal(brow[20])).rstrip('0').rstrip('.').replace(".",",")
         rd_y = "{:.3f}".format(Decimal(brow[21])).rstrip('0').rstrip('.').replace(".",",")
 
-        #print "nummeraanduiding = ", nummeraanduiding
-        #print "adresseerbaarobject = ", adresseerbaarobject
-        #print "pandid = ", pandid
-        #print "pandstatus = ", pandstatus
-        #print "pandbouwjaar = ", pandbouwjaar
-        #print "openbareruimtenaam = ", openbareruimtenaam
-        #print "postcode = ", postcode
-        #print "huisnummer = ", huisnummer
-        #print "huisletter = ", huisletter
-        #print "huisnummertoevoeging = ", huisnummertoevoeging
-        #print "woonplaatsnaam = ", woonplaatsnaam
-        #print "gemeentenaam = ", gemeentenaam
-        #print "provincienaam = ", provincienaam
-        #print "verblijfsobjectgebruiksdoel = ", verblijfsobjectgebruiksdoel
-        #print "oppervlakteverblijfsobject = ", oppervlakteverblijfsobject
-        #print "lon = ", lon
-        #print "lat = ", lat
-        #print "rd_x = ", rd_x
-        #print "rd_y = ", rd_y, "\n"
+        #print("nummeraanduiding = ", nummeraanduiding)
+        #print("adresseerbaarobject = ", adresseerbaarobject)
+        #print("pandid = ", pandid)
+        #print("pandstatus = ", pandstatus)
+        #print("pandbouwjaar = ", pandbouwjaar)
+        #print("openbareruimtenaam = ", openbareruimtenaam)
+        #print("postcode = ", postcode)
+        #print("huisnummer = ", huisnummer)
+        #print("huisletter = ", huisletter)
+        #print("huisnummertoevoeging = ", huisnummertoevoeging)
+        #print("woonplaatsnaam = ", woonplaatsnaam)
+        #print("gemeentenaam = ", gemeentenaam)
+        #print("provincienaam = ", provincienaam)
+        #print("verblijfsobjectgebruiksdoel = ", verblijfsobjectgebruiksdoel)
+        #print("oppervlakteverblijfsobject = ", oppervlakteverblijfsobject)
+        #print("lon = ", lon)
+        #print("lat = ", lat)
+        #print("rd_x = ", rd_x)
+        #print("rd_y = ", rd_y, "\n")
 
         with io.open(OutputFile, 'a', encoding='utf-8-sig') as logfile:
             logfile.write(u"%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s" % (uid,req,nummeraanduiding,adresseerbaarobject,pandid,pandstatus,pandbouwjaar,openbareruimtenaam,postcode,huisnummer,huisletter,huisnummertoevoeging,woonplaatsnaam,gemeentenaam,provincienaam,verblijfsobjectgebruiksdoel,oppervlakteverblijfsobject,verblijfsobjectstatus,typeadresseerbaarobject,nevenadres,lon,lat,rd_x,rd_y,mult))

--- a/bag/src/geocode/GeoCode-pc-hn-ext.py
+++ b/bag/src/geocode/GeoCode-pc-hn-ext.py
@@ -7,11 +7,6 @@ import psycopg2
 from psycopg2.extensions import AsIs
 from decimal import Decimal
 
-# encoding=ISO-8859-1 (utf8)
-import sys
-reload(sys)
-sys.setdefaultencoding('ISO-8859-1')
-
 #set default args as -h , if no args:
 if len(sys.argv) == 1: sys.argv[1:] = ["-h"]
 

--- a/bag/src/geocode/GeoCode-pc-hn-hl-tv.py
+++ b/bag/src/geocode/GeoCode-pc-hn-hl-tv.py
@@ -16,16 +16,16 @@ sys.setdefaultencoding('ISO-8859-1')
 if len(sys.argv) == 1: sys.argv[1:] = ["-h"]
 
 if sys.argv[1] == "-h":
-    print 'Usage: '+os.path.basename(sys.argv[0])+' <input file name> <input adres name>'
-    print 'Input format: postcode;huisnummer;huisletter;huisnummertoevoeging;<extra data columns>'
-    print 'Input File format: signed UTF-8 (With BOM), can be changed by editing this script @ line 32'
-    print 'The <extra data columns> are added to the signed UTF-8 output file after the BAG data columns'
-    print '<input adres name> to rename the \'Input adres\' column. \'Input\' is replaced with the given name'
-    print 'Example: GeoCode-pc-hn-ext.py Adreslijst-INS.csv INSPIRE  to geocode an INSPIRE list'
+    print('Usage: '+os.path.basename(sys.argv[0])+' <input file name> <input adres name>')
+    print('Input format: postcode;huisnummer;huisletter;huisnummertoevoeging;<extra data columns>')
+    print('Input File format: signed UTF-8 (With BOM), can be changed by editing this script @ line 32')
+    print('The <extra data columns> are added to the signed UTF-8 output file after the BAG data columns')
+    print('<input adres name> to rename the \'Input adres\' column. \'Input\' is replaced with the given name')
+    print('Example: GeoCode-pc-hn-ext.py Adreslijst-INS.csv INSPIRE  to geocode an INSPIRE list')
     sys.exit(0)
 
 InputFile = sys.argv[1].rstrip('.csv')+'.csv'
-print 'InputFile =', InputFile
+print('InputFile =', InputFile)
 
 # Input CSV with postcode;huisnummer;huisletter;huisnummertoevoeging;<extra data columns>
 # encoding = utf-8-sig, utf8, ISO-8859-1, windows-1252
@@ -34,30 +34,30 @@ SIDReader = csv.reader(SIDFile,delimiter=';')
 
 # Output file name
 OutputFile = InputFile.rstrip('.csv')+'-geocoded.csv'
-print 'OutputFile =', OutputFile
+print('OutputFile =', OutputFile)
 
 if len(sys.argv)>2:
     InAdres = sys.argv[2]+' adres'
 else:
     InAdres = 'Input adres'
-print 'Input adres name =', InAdres
+print('Input adres name =', InAdres)
 
 header=next(SIDReader) # Read first line
 ncol=len(header) # Count columns
-#print 'Number of columns = ', ncol
-#print 'Header = ', header
+#print('Number of columns = ', ncol)
+#print('Header = ', header)
 
 if ncol<4:
-    print 'Only', ncol, 'columns in input file! Minimum is: postcode;huisnummer;huisletter;huisnummertoevoeging'
+    print('Only', ncol, 'columns in input file! Minimum is: postcode;huisnummer;huisletter;huisnummertoevoeging')
     sys.exit(2)
 else:
-    print 'Adding', (ncol-4), 'columns to output file'
+    print('Adding', (ncol-4), 'columns to output file')
 
 SID = list(SIDReader)
 rowcount = 0
 uid = 1
 row_count = sum(1 for row in SID) #Count rows
-#print 'Number of rows = ', row_count
+#print('Number of rows = ', row_count)
 
 # Column Selection from database
 SEL = "nummeraanduiding, adresseerbaarobject, pandid, pandstatus, pandbouwjaar, openbareruimtenaam, postcode, huisnummer, huisletter, huisnummertoevoeging, woonplaatsnaam, gemeentenaam, provincienaam, verblijfsobjectgebruiksdoel, oppervlakteverblijfsobject, verblijfsobjectstatus, typeadresseerbaarobject, nevenadres, st_x(ST_transform(geopunt, 4326)), st_y(ST_transform(geopunt, 4326)), st_x(geopunt), st_y(geopunt)"
@@ -85,55 +85,55 @@ for row in SID:
     req = req.strip()
     mult = ''
 
-    #print 'Requested Postcode =', req
-    print 'Progress = ', ((uid*100)/row_count), '%\r',
+    #print('Requested Postcode =', req)
+    print('Progress = ', ((uid*100)/row_count), '%\r',)
     rowcount += 1
 
     if pc == '':
-        print 'Line',rowcount+1,'without Postcode found! skipping!\n'
+        print('Line',rowcount+1,'without Postcode found! skipping!\n')
         uid += 1
         continue
 
-    #print 'Postcode =', pc, "huisnummer", hn, "huisletter", hl, " en huisnummertoevoeging", ht
+    #print('Postcode =', pc, "huisnummer", hn, "huisletter", hl, " en huisnummertoevoeging", ht)
 
     if hl == "" and ht == "":
-        #print "PC+HN"
+        #print("PC+HN")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1],))
     elif hl == "":
-        #print "PC+HN+ht"
+        #print("PC+HN+ht")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LPAD(LOWER(huisnummertoevoeging)::text, 4, '0') = LPAD(LOWER(%s), 4, '0') AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], ht,))
     elif ht == "":
-        #print "PC+HN+HL"
+        #print("PC+HN+HL")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND huisnummertoevoeging IS NULL AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], hl,))
     else:
-        #print "PC+HN+HL+ht"
+        #print("PC+HN+HL+ht")
         cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND LPAD(LOWER(huisnummertoevoeging)::text, 4, '0') = LPAD(LOWER(%s), 4, '0') AND left(verblijfsobjectstatus, 26) = 'Verblijfsobject in gebruik'", (AsIs(SEL), row[0], row[1], hl, ht,))
 
     rows = cur.fetchall()
 
     if cur.rowcount < 1 :
-        #print "No location found, trying not existing VBO!\n"
+        #print("No location found, trying not existing VBO!\n")
 
 
         if hl == "" and ht == "":
-            #print "PC+HN"
+            #print("PC+HN")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND huisnummertoevoeging IS NULL", (AsIs(SEL), row[0], row[1],))
         elif hl == "":
-            #print "PC+HN+ht"
+            #print("PC+HN+ht")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND huisletter IS NULL AND LPAD(LOWER(huisnummertoevoeging)::text, 4, '0') = LPAD(LOWER(%s), 4, '0')", (AsIs(SEL), row[0], row[1], ht,))
         elif ht == "":
-            #print "PC+HN+HL"
+            #print("PC+HN+HL")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND huisnummertoevoeging IS NULL", (AsIs(SEL), row[0], row[1], hl,))
         else:
-            #print "PC+HN+HL+ht"
+            #print("PC+HN+HL+ht")
             cur.execute("SELECT %s FROM geo_adres_full WHERE postcode = %s AND huisnummer = %s AND LOWER(huisletter) = LOWER(%s) AND LPAD(LOWER(huisnummertoevoeging)::text, 4, '0') = LPAD(LOWER(%s), 4, '0')", (AsIs(SEL), row[0], row[1], hl, ht,))
     
         rows = cur.fetchall()
 
-    #print "number of location(s)", cur.rowcount, "\n"
+    #print("number of location(s)", cur.rowcount, "\n")
 
     if cur.rowcount < 1 :
-        #print "No location found!\n"
+        #print("No location found!\n")
         with io.open(OutputFile, 'a', encoding='utf-8-sig') as logfile:
             logfile.write(u"%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s" % (uid,req,'','','','','','Actueel BAG adres onbekend','','','','','','','','','','','','',0,0,0,0,mult))
             for item in range(ncol-4):
@@ -148,8 +148,8 @@ for row in SID:
     if cur.rowcount > 1 :
         row_count += (cur.rowcount-1)
         mult = str(cur.rowcount)+' VBO\'s op 1 adres'
-        #print "More than one object found in BAG database!"
-        #print 'Requested Postcode =', pc, "huisnummer", hn, "huisletter", hl, " en huisnummertoevoeging", ht, "\n"
+        #print("More than one object found in BAG database!")
+        #print('Requested Postcode =', pc, "huisnummer", hn, "huisletter", hl, " en huisnummertoevoeging", ht, "\n")
     else:
         mult = ''
 
@@ -177,25 +177,25 @@ for row in SID:
         rd_x = "{:.3f}".format(Decimal(brow[20])).rstrip('0').rstrip('.').replace(".",",")
         rd_y = "{:.3f}".format(Decimal(brow[21])).rstrip('0').rstrip('.').replace(".",",")
 
-        #print "nummeraanduiding = ", nummeraanduiding
-        #print "adresseerbaarobject = ", adresseerbaarobject
-        #print "pandid = ", pandid
-        #print "pandstatus = ", pandstatus
-        #print "pandbouwjaar = ", pandbouwjaar
-        #print "openbareruimtenaam = ", openbareruimtenaam
-        #print "postcode = ", postcode
-        #print "huisnummer = ", huisnummer
-        #print "huisletter = ", huisletter
-        #print "huisnummertoevoeging = ", huisnummertoevoeging
-        #print "woonplaatsnaam = ", woonplaatsnaam
-        #print "gemeentenaam = ", gemeentenaam
-        #print "provincienaam = ", provincienaam
-        #print "verblijfsobjectgebruiksdoel = ", verblijfsobjectgebruiksdoel
-        #print "oppervlakteverblijfsobject = ", oppervlakteverblijfsobject
-        #print "lon = ", lon
-        #print "lat = ", lat
-        #print "rd_x = ", rd_x
-        #print "rd_y = ", rd_y, "\n"
+        #print("nummeraanduiding = ", nummeraanduiding)
+        #print("adresseerbaarobject = ", adresseerbaarobject)
+        #print("pandid = ", pandid)
+        #print("pandstatus = ", pandstatus)
+        #print("pandbouwjaar = ", pandbouwjaar)
+        #print("openbareruimtenaam = ", openbareruimtenaam)
+        #print("postcode = ", postcode)
+        #print("huisnummer = ", huisnummer)
+        #print("huisletter = ", huisletter)
+        #print("huisnummertoevoeging = ", huisnummertoevoeging)
+        #print("woonplaatsnaam = ", woonplaatsnaam)
+        #print("gemeentenaam = ", gemeentenaam)
+        #print("provincienaam = ", provincienaam)
+        #print("verblijfsobjectgebruiksdoel = ", verblijfsobjectgebruiksdoel)
+        #print("oppervlakteverblijfsobject = ", oppervlakteverblijfsobject)
+        #print("lon = ", lon)
+        #print("lat = ", lat)
+        #print("rd_x = ", rd_x)
+        #print("rd_y = ", rd_y, "\n")
 
         with io.open(OutputFile, 'a', encoding='utf-8-sig') as logfile:
             logfile.write(u"%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s" % (uid,req,nummeraanduiding,adresseerbaarobject,pandid,pandstatus,pandbouwjaar,openbareruimtenaam,postcode,huisnummer,huisletter,huisnummertoevoeging,woonplaatsnaam,gemeentenaam,provincienaam,verblijfsobjectgebruiksdoel,oppervlakteverblijfsobject,verblijfsobjectstatus,typeadresseerbaarobject,nevenadres,lon,lat,rd_x,rd_y,mult))

--- a/bag/src/geocode/GeoCode-pc-hn-hl-tv.py
+++ b/bag/src/geocode/GeoCode-pc-hn-hl-tv.py
@@ -7,10 +7,7 @@ import psycopg2
 from psycopg2.extensions import AsIs
 from decimal import Decimal
 
-# encoding=ISO-8859-1 (utf8)
 import sys
-reload(sys)
-sys.setdefaultencoding('ISO-8859-1')
 
 #set default args as -h , if no args:
 if len(sys.argv) == 1: sys.argv[1:] = ["-h"]

--- a/bag/src/log.py
+++ b/bag/src/log.py
@@ -9,7 +9,7 @@ import traceback
 # Standard output log writer
 class StdOutput:
     def __call__(self, message):
-        print (message)
+        print(message)
         sys.stdout.flush()
 
 

--- a/bag/src/oracledb.py
+++ b/bag/src/oracledb.py
@@ -64,7 +64,7 @@ class Database:
             self.cursor.execute(script)
             self.connection.commit()
             Log.log.info('script uitgevoerd')
-        except cx_Oracle.DatabaseError, e:
+        except cx_Oracle.DatabaseError as e:
             Log.log.error("fout: procedures :%s" % str(e))
 
     def verbind(self, initdb=False):
@@ -78,7 +78,7 @@ class Database:
 
             self.zet_schema()
             Log.log.info("verbonden met sid %s" % (self.sid))
-        except Exception, e:
+        except Exception as e:
             Log.log.error("fout %s: kan geen verbinding maken met sid %s" % (str(e), self.sid))
             sys.exit()
 
@@ -88,6 +88,6 @@ class Database:
                 self.cursor.execute(sql, parameters)
             else:
                 self.cursor.execute(sql)
-        except (cx_Oracle.IntegrityError, cx_Oracle.ProgrammingError), e:
+        except (cx_Oracle.IntegrityError, cx_Oracle.ProgrammingError) as e:
             Log.log.error("fout %s voor query: %s" % (str(e), str(self.cursor.mogrify(sql, parameters))))
             return self.cursor.rowcount

--- a/bag/src/postgresdb.py
+++ b/bag/src/postgresdb.py
@@ -122,7 +122,7 @@ class Database:
             rows = self.cursor.fetchall()
             self.connection.commit()
             return rows
-        except (psycopg2.Error,), foutmelding:
+        except (psycopg2.Error,) as foutmelding:
             Log.log.error("*** FOUT *** Kan SQL-statement '%s' niet uitvoeren:\n %s" % (sql, foutmelding))
             return []
 

--- a/bag/src/processor.py
+++ b/bag/src/processor.py
@@ -369,12 +369,7 @@ class Processor:
 
     # Experimenteel: inlezen via COPY ipv INSERT: fikse snelheidswinst
     def dbStoreCopy(self, mode):
-        try:
-            from cStringIO import StringIO
-            Log.log.info("running with cStringIO")
-        except Exception:
-            from StringIO import StringIO
-            Log.log.info("running with StringIO")
+        from io import StringIO
 
         import codecs
         Log.log.startTimer("dbStart mode = " + mode)

--- a/bag/src/processor.py
+++ b/bag/src/processor.py
@@ -371,7 +371,6 @@ class Processor:
     def dbStoreCopy(self, mode):
         from io import StringIO
 
-        import codecs
         Log.log.startTimer("dbStart mode = " + mode)
         self.database.verbind()
 
@@ -392,10 +391,8 @@ class Processor:
                 # Maak buffer eenmalig aan per tabel
                 if bagObject.naam() not in buffers:
                     buffer = StringIO()
-                    # cStringIO heeft niet standaard UTF-8 support en BAG is in UTF-8
-                    bufferUTF8 = codecs.getwriter("utf8")(buffer)
 
-                    buffers[bagObject.naam()] = bufferUTF8
+                    buffers[bagObject.naam()] = buffer
 
                 # Voeg de inhoud aan buffer toe
                 bagObject.maakCopySQL(buffers[bagObject.naam()])
@@ -409,9 +406,7 @@ class Processor:
                 if relatie.relatieNaam() not in buffers:
                     buffer = StringIO()
 
-                    # cStringIO heeft niet standaard UTF-8 support en BAG is in UTF-8
-                    bufferUTF8 = codecs.getwriter("utf8")(buffer)
-                    buffers[relatie.relatieNaam()] = bufferUTF8
+                    buffers[relatie.relatieNaam()] = buffer
 
                 buffers[relatie.relatieNaam()].write(relatie.sql)
                 # Kolom namen

--- a/bag/src/processor.py
+++ b/bag/src/processor.py
@@ -428,7 +428,7 @@ class Processor:
         for table in buffers:
             buf = buffers[table]
             buf.seek(0)
-            self.database.cursor.copy_from(buf, table, sep='~', null='\\\N', columns=columns[table])
+            self.database.cursor.copy_from(buf, table, sep='~', null=r'\N', columns=columns[table])
 
             buf.close()
 

--- a/bag/src/processor.py
+++ b/bag/src/processor.py
@@ -452,10 +452,10 @@ class Processor:
 # # Writing to a buffer
 # output = StringIO()
 # output.write('This goes into the buffer. ')
-# print >>output, 'And so does this.'
+# print(>>output, 'And so does this.')
 #
 # # Retrieve the value written
-# print output.getvalue()
+# print(output.getvalue())
 #
 # output.close() # discard buffer memory
 #
@@ -463,5 +463,5 @@ class Processor:
 # input = StringIO('Inital value for read buffer')
 #
 # # Read from the buffer
-# print input.read()
+# print(input.read())
 #


### PR DESCRIPTION
Python 2 is EOL since 2020-01-01, high time to switch to Python 3.

The port is quite straight forward.

XML needs to be read as bytes, because parsing strings with an XML declaration is not supported.

This requires later decoding to create a geometry from the GML.

The `gemeentelijke-indeling.py` script uses [xlrd](https://pypi.org/project/xlrd/) instead of [pyExcelerator](https://pypi.org/project/pyExcelerator/) for Python 3 support.

The remaining changes are mostly `print` & `Exception` syntax, only using `io.StringIO` & `io.BytesIO`, and not settings the default encoding.