### PR TITLE
Decode Levering XML to string.

### DIFF
--- a/bag/src/processor.py
+++ b/bag/src/processor.py
@@ -296,7 +296,7 @@ class Processor:
             # Meta data: info over levering
 
             # Sla hele file op
-            self.database.log_meta("levering_xml", etree.tostring(node, pretty_print=True))
+            self.database.log_meta("levering_xml", etree.tostring(node, pretty_print=True).decode())
 
             # Extraheer BAG lever datum
             #            <v202:LVC-Extract>


### PR DESCRIPTION
With the switch to Python3 `etree.tostring()` returns bytes.

Before inserting the content of `Leveringsdocument-BAG-Extract.xml` it should be decoded to a string to not store bytes in the database.