### PR TITLE
Toevoeging push/popd aan BRK etl.sh

### DIFF
--- a/brk/etl/etl.sh
+++ b/brk/etl/etl.sh
@@ -8,6 +8,11 @@
 # Author: Just van den Broecke
 #
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $DIR >/dev/null
+
+NLX_HOME=../..
+
 # Gebruik Stetl meegeleverd met NLExtract (kan in theorie ook Stetl via pip install stetl zijn)
 if [ -z "$STETL_HOME" ]; then
   STETL_HOME=../../externals/stetl
@@ -37,3 +42,5 @@ host_options_file=options/`hostname`.args
 # Uiteindelijke commando. Kan ook gewoon "stetl -c etl-brk.cfg -a ..." worden indien Stetl installed
 # python $STETL_HOME/stetl/main.py -c conf/etl-brk.cfg -a "$pg_options temp_dir=temp max_features=$max_features gml_files=$gml_files $multi $spatial_extent"
 python $STETL_HOME/stetl/main.py -c conf/etl-brk.cfg -a $options_file
+
+popd >/dev/null


### PR DESCRIPTION
In alle etl.sh-scripts wordt gebruik gemaakt van pushd / popd om de paden correct over te nemen, zodat dit script ook aangeroepen kan worden vanuit andere mappen zonder fouten in verwijzingen. Bij de BRK ontbraken deze regels in dit script.

Deze PR voegt deze regels toe zodat ook de BRK etl.sh aangeroepen kan worden vanuit een andere map als waarin etl.sh staat.