### PR TITLE
Fix python detection.

### DIFF
--- a/bag/bin/bag-extract.sh
+++ b/bag/bin/bag-extract.sh
@@ -17,10 +17,22 @@ BASEDIR=`(cd "$BASEDIR"; pwd)`
 PY_SCRIPT=$BASEDIR/src/bagextract.py
 
 # uitvoeren Python script met alle meegegeven args
-ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
-if [ $ret -eq 0 ]; then
-    #Python 3 is de standaard, roep python aan.
-    python $PY_SCRIPT $@
+PYTHON="$(command -v python)"
+if [ -z "${PYTHON}" ]; then
+  PYTHON="$(command -v python3)"
+  if [ -z "${PYTHON}" ]; then
+    echo "Error: No usuable python found in PATH"
+    exit 1
+  fi
 else
-    python3 $PY_SCRIPT $@
+  ret=`"${PYTHON}" -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
+  if [ $ret -ne 0 ]; then
+    PYTHON="$(command -v python3)"
+    if [ -z "${PYTHON}" ]; then
+      echo "Error: No usuable python found in PATH"
+      exit 1
+    fi
+  fi
 fi
+
+"${PYTHON}" $PY_SCRIPT "$@"

--- a/bag/bin/gemeentelijke-indeling.sh
+++ b/bag/bin/gemeentelijke-indeling.sh
@@ -17,10 +17,22 @@ BASEDIR=`(cd "$BASEDIR"; pwd)`
 PY_SCRIPT=$BASEDIR/src/gemeentelijke-indeling.py
 
 # uitvoeren Python script met alle meegegeven args
-ret=`python -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
-if [ $ret -eq 0 ]; then
-    #Python 3 is de standaard, roep python aan.
-    python $PY_SCRIPT "$@"
+PYTHON="$(command -v python)"
+if [ -z "${PYTHON}" ]; then
+  PYTHON="$(command -v python3)"
+  if [ -z "${PYTHON}" ]; then
+    echo "Error: No usuable python found in PATH"
+    exit 1
+  fi
 else
-    python3 $PY_SCRIPT "$@"
+  ret=`"${PYTHON}" -c 'import sys; print("%i" % (sys.hexversion<0x03000000))'`
+  if [ $ret -ne 0 ]; then
+    PYTHON="$(command -v python3)"
+    if [ -z "${PYTHON}" ]; then
+      echo "Error: No usuable python found in PATH"
+      exit 1
+    fi
+  fi
 fi
+
+"${PYTHON}" $PY_SCRIPT "$@"


### PR DESCRIPTION
On Debian bullseye/sid there is no `python` by default any more, either the `python-is-python2` or `python-is-python3` package needs to be installed to provide `/usr/bin/python`.

When there is no `python` in `PATH` the version detection in `bag-extract.sh` & `gemeentelijke-indeling.sh` fail.

This PR fixes that by not assuming that `python` is available, it first tries to find that and ensure it's version 3, or it tries to find `python3`.