### PR TITLE
Add BAGv2 Atom feed

### DIFF
--- a/bagv2/README.md
+++ b/bagv2/README.md
@@ -6,6 +6,7 @@ For now assumed this can be used in the Stetl Chain.
 ## Download van Kadaster
 
 * via https://extracten.bag.kadaster.nl/lvbag/extracten/
+  of https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml
 * BAG v1: tot april 2021, met handmatige controle, voor enkele problemen
 * april-sept 2021 ook maar zonder controle, verwacht 99.9% correct
 * tarieven: https://www.kadaster.nl/-/tarieven-2021 


### PR DESCRIPTION
The extracten.bag.kadaster.nl server is being phased out:
> **Vanaf 11 oktober worden er geen nieuwe BAG 2.0 Extracten gepubliceerd op deze server.**
Wilt u gebruik blijven maken van het BAG 2.0 Extract? Kijk dan op [de productpagina van het BAG 2.0 Extract](https://www.kadaster.nl/zakelijk/producten/adressen-en-gebouwen/bag-2.0-extract) voor de verschillende mogelijkheden.
> 
> Vanaf januari 2022 is de Externe server niet meer te benaderen. Hiermee stopt de mogelijkheid om de oude BAG 2.0 Extracten te downloaden.

Alternatively we could document: https://www.kadaster.nl/-/kosteloze-download-bag-2.0-extract