### PR TITLE
Extract SchemaInfo from Leveringsdocument-BAG-Extract.xml.

### DIFF
--- a/bagv2/etl/sql/create-meta.sql
+++ b/bagv2/etl/sql/create-meta.sql
@@ -18,8 +18,6 @@ INSERT INTO nlx_bag_info (sleutel,waarde)
 INSERT INTO nlx_bag_info (sleutel,waarde)
         VALUES ('schema_creatie', to_char(current_timestamp, 'DD-Mon-IYYY HH24:MI:SS'));
 INSERT INTO nlx_bag_info (sleutel,waarde)
-        VALUES ('bag_xsd_versie', '20200601');
-INSERT INTO nlx_bag_info (sleutel,waarde)
         VALUES ('start_base_etl', to_char(current_timestamp, 'DD-Mon-IYYY HH24:MI:SS'));
 
 

--- a/bagv2/etl/xsl/Leveringsdoc2gml.xsl
+++ b/bagv2/etl/xsl/Leveringsdoc2gml.xsl
@@ -31,6 +31,7 @@ Author:  Just van den Broecke, Just Objects B.V.
             </gml:boundedBy>
 
             <xsl:apply-templates select="//xb:SelectieGegevens"/>
+            <xsl:apply-templates select="//xb:SchemaInfo"/>
         </ogr:FeatureCollection>
     </xsl:template>
 
@@ -41,7 +42,35 @@ Author:  Just van den Broecke, Just Objects B.V.
                 <ogr:sleutel>extract_datum</ogr:sleutel>
                 <ogr:waarde>
                      <xsl:value-of select="selecties-extract:StandTechnischeDatum/text()"/>
-                 </ogr:waarde>
+                </ogr:waarde>
+                <ogr:geometry>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG:28992">
+                        <gml:coordinates>20000,450000</gml:coordinates>
+                     </gml:Point>
+                </ogr:geometry>
+            </ogr:nlx_bag_info>
+        </gml:featureMember>
+    </xsl:template>
+    <xsl:template match="xb:SchemaInfo">
+        <gml:featureMember>
+            <ogr:nlx_bag_info>
+                <ogr:sleutel>bag_xsd_naam</ogr:sleutel>
+                <ogr:waarde>
+                     <xsl:value-of select="xb:naam/text()"/>
+                </ogr:waarde>
+                <ogr:geometry>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG:28992">
+                        <gml:coordinates>20000,450000</gml:coordinates>
+                     </gml:Point>
+                </ogr:geometry>
+            </ogr:nlx_bag_info>
+        </gml:featureMember>
+        <gml:featureMember>
+            <ogr:nlx_bag_info>
+                <ogr:sleutel>bag_xsd_versie</ogr:sleutel>
+                <ogr:waarde>
+                     <xsl:value-of select="xb:versie/text()"/>
+                </ogr:waarde>
                 <ogr:geometry>
                     <gml:Point srsName="urn:ogc:def:crs:EPSG:28992">
                         <gml:coordinates>20000,450000</gml:coordinates>


### PR DESCRIPTION
In plaats van de `bag_xsd_versie` waarde te hardcoden wordt de `SchemaInfo` uit `Leveringsdocument-BAG-Extract.xml` gebruikt.

Fixes: #333