### PR TITLE
BAGv2 Bump GDAL versie naar 3.4.0.

### DIFF
--- a/bagv2/etl/README.md
+++ b/bagv2/etl/README.md
@@ -13,14 +13,14 @@ De voornaamste kenmerken daarvan zijn:
 Toch was er geen custom Python nodig: de BAG v2 wordt geheel verwerkt met Stetl.
 De belangrijkste functies die via Stetl worden aangewend:
 
-* [GDAL LVBAG Driver](https://gdal.org/drivers/vector/lvbag.html) (GDAL v3.2.2 of hoger nodig)
+* [GDAL LVBAG Driver](https://gdal.org/drivers/vector/lvbag.html) (GDAL v3.4.0 of hoger nodig)
 * [GDAL VSI](https://gdal.org/user/virtual_file_systems.html) Zip handlers voor geneste .zip files
 * XSLT voor "niet-BAG-model" XML-bestanden zoals Woonplaats-Gemeenten en Leverings
 * CSV input naar Postgres output voor CBS Gemeenten en Provincies
 
 ## Geen Docker
 
-Kan wel maar is hoge versie GDAL nodig, minimaal 3.2.2.
+Kan wel maar is hoge versie GDAL nodig, minimaal 3.4.0.
 
 ```
 # Will use options/default.args


### PR DESCRIPTION
De LVBAG driver is toegevoegd in GDAL 3.2.0.
In GDAL 3.3.0 is het `identificatie` veld toegevoegd.
En in GDAL 3.4.0 zijn `woonplaatsRef` (voor `Nummeraanduiding` objecten)
en `verkorteNaam` (voor `OpenbareRuimte` objecten) toegevoegd.

Fixes: #330