### PR TITLE
Gebruik BAG stand datum in plaats van NOW/LOCALTIMESTAMP.

### DIFF
--- a/bagv2/etl/sql/create-indexes.sql
+++ b/bagv2/etl/sql/create-indexes.sql
@@ -67,6 +67,9 @@ DROP INDEX IF EXISTS adresseerbaarobjectnevenadreskey CASCADE;
 CREATE INDEX
         adresseerbaarobjectnevenadreskey ON adresseerbaarobjectnevenadres USING btree (identificatie,voorkomenidentificatie, begindatumTijdvakGeldigheid, nevenadres);
 
+DROP INDEX IF EXISTS nlx_bag_info_key CASCADE;
+CREATE INDEX nlx_bag_info_key ON nlx_bag_info USING btree (sleutel);
+
 INSERT INTO nlx_bag_log (actie, bestand) VALUES ('end_indexing', 'create-indexes.sql');
 
 INSERT INTO nlx_bag_info (sleutel,waarde)

--- a/bagv2/etl/sql/create-views.sql
+++ b/bagv2/etl/sql/create-views.sql
@@ -3,9 +3,19 @@
 -- Via Views kunnen actuele en bestaande objecten uitgefilterd worden.
 -- Author: Just van den Broecke
 
+-- Gebruik BAG stand datum in plaats van NOW/LOCALTIMESTAMP
+CREATE FUNCTION extract_datum()
+        RETURNS timestamp
+             AS $$
+                   SELECT waarde::timestamp
+                     FROM nlx_bag_info
+                    WHERE sleutel = 'extract_datum'
+                $$
+       LANGUAGE SQL;
+
 -- Feitelijk is de "acteel" definitie:
--- begingeldigheid <= now()
---  AND (eindgeldigheid is NULL OR eindgeldigheid >= now())
+-- begingeldigheid <= extract_datum()
+--  AND (eindgeldigheid is NULL OR eindgeldigheid >= extract_datum())
 --  AND (tijdstipinactief is NULL)
 --  AND (tijdstipnietbaglv is NULL)
 
@@ -15,16 +25,16 @@ DROP VIEW IF EXISTS ligplaatsactueel;
 CREATE VIEW ligplaatsactueel AS
     SELECT * FROM ligplaats
     WHERE
-      beginDatumTijdvakGeldigheid <= now()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+      beginDatumTijdvakGeldigheid <= extract_datum()
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
       AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS ligplaatsactueelbestaand;
 CREATE VIEW ligplaatsactueelbestaand AS
     SELECT * FROM ligplaats
     WHERE
-        beginDatumTijdvakGeldigheid <= now()
-        AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+        beginDatumTijdvakGeldigheid <= extract_datum()
+        AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
         AND aanduidingrecordinactief is FALSE
         AND ligplaatsStatus <> 'Plaats ingetrokken'::ligplaatsStatus;
 
@@ -34,16 +44,16 @@ CREATE VIEW nummeraanduidingactueel AS
     SELECT *
     FROM nummeraanduiding
     WHERE
-      beginDatumTijdvakGeldigheid <= now()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+      beginDatumTijdvakGeldigheid <= extract_datum()
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
       AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS nummeraanduidingactueelbestaand;
 CREATE VIEW nummeraanduidingactueelbestaand AS
     SELECT * FROM nummeraanduiding
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND nummeraanduidingStatus <> 'Naamgeving ingetrokken'::nummeraanduidingStatus;
 
@@ -52,16 +62,16 @@ DROP VIEW IF EXISTS openbareruimteactueel;
 CREATE VIEW openbareruimteactueel AS
     SELECT * FROM openbareruimte
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS openbareruimteactueelbestaand;
 CREATE VIEW openbareruimteactueelbestaand AS
     SELECT * FROM openbareruimte
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND openbareruimteStatus <> 'Naamgeving ingetrokken'::openbareRuimteStatus;
 
@@ -70,8 +80,8 @@ DROP VIEW IF EXISTS pandactueel;
 CREATE VIEW pandactueel AS
     SELECT * FROM pand
     WHERE
-      beginDatumTijdvakGeldigheid <= now()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+      beginDatumTijdvakGeldigheid <= extract_datum()
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
       AND aanduidingrecordinactief is FALSE 
       AND pand.geom_valid = TRUE;
 
@@ -79,8 +89,8 @@ DROP VIEW IF EXISTS pandactueelbestaand;
 CREATE VIEW pandactueelbestaand AS
     SELECT * FROM pand
     WHERE
-     beginDatumTijdvakGeldigheid <= now()
-     AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+     beginDatumTijdvakGeldigheid <= extract_datum()
+     AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
      AND aanduidingrecordinactief is FALSE
      AND (pandStatus <> 'Niet gerealiseerd pand'::pandStatus
      AND pandStatus <> 'Pand gesloopt'::pandStatus
@@ -93,16 +103,16 @@ DROP VIEW IF EXISTS standplaatsactueel;
 CREATE VIEW standplaatsactueel AS
     SELECT * FROM standplaats
     WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS standplaatsactueelbestaand;
 CREATE VIEW standplaatsactueelbestaand AS
     SELECT * FROM standplaats
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND standplaatsStatus <> 'Plaats ingetrokken'::standplaatsStatus;
 
@@ -111,8 +121,8 @@ DROP VIEW IF EXISTS verblijfsobjectactueel;
 CREATE VIEW verblijfsobjectactueel AS
     SELECT * FROM verblijfsobject
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 
@@ -120,8 +130,8 @@ DROP VIEW IF EXISTS verblijfsobjectactueelbestaand;
 CREATE VIEW verblijfsobjectactueelbestaand AS
     SELECT * FROM verblijfsobject
     WHERE
-      beginDatumTijdvakGeldigheid <= now()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+      beginDatumTijdvakGeldigheid <= extract_datum()
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
       AND aanduidingrecordinactief is FALSE
       AND (verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject'::verblijfsobjectStatus
       AND verblijfsobjectStatus  <> 'Verblijfsobject ingetrokken'::verblijfsobjectStatus
@@ -136,16 +146,16 @@ DROP VIEW IF EXISTS woonplaatsactueel;
 CREATE VIEW woonplaatsactueel AS
   SELECT * FROM woonplaats
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS woonplaatsactueelbestaand;
 CREATE VIEW woonplaatsactueelbestaand AS
   SELECT * FROM woonplaats
   WHERE
-    beginDatumTijdvakGeldigheid <= now()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= now())
+    beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND woonplaatsStatus  <> 'Woonplaats ingetrokken'::woonplaatsStatus;
 
@@ -161,8 +171,8 @@ CREATE VIEW gemeente_woonplaatsactueelbestaand AS
             gw.status
     FROM gemeente_woonplaats as gw
   WHERE
-    gw.beginDatumTijdvakGeldigheid <= now()
-    AND (gw.eindDatumTijdvakGeldigheid is NULL OR gw.eindDatumTijdvakGeldigheid >= now())
+    gw.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (gw.eindDatumTijdvakGeldigheid is NULL OR gw.eindDatumTijdvakGeldigheid >= extract_datum())
     AND gw.status = 'definitief';
 
 DROP VIEW IF EXISTS provincie_gemeenteactueelbestaand;
@@ -176,8 +186,8 @@ CREATE VIEW provincie_gemeenteactueelbestaand AS
             pg.einddatum
     FROM provincie_gemeente AS pg
   WHERE
-    pg.begindatum <= now()
-    AND (pg.einddatum IS NULL OR pg.einddatum >= now());
+    pg.begindatum <= extract_datum()
+    AND (pg.einddatum IS NULL OR pg.einddatum >= extract_datum());
 
 
 -- START RELATIE TABELLEN
@@ -187,18 +197,18 @@ CREATE VIEW adresseerbaarobjectnevenadresactueel AS
     SELECT *
     FROM adresseerbaarobjectnevenadres as aon
   WHERE
-    aon.beginDatumTijdvakGeldigheid <= now()
-    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= now())
-    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= now());
+    aon.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS adresseerbaarobjectnevenadresactueelbestaand;
 CREATE VIEW adresseerbaarobjectnevenadresactueelbestaand AS
     SELECT *
     FROM adresseerbaarobjectnevenadres as aon
   WHERE
-    aon.beginDatumTijdvakGeldigheid <= now()
-    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= now())
-    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= now())
+    aon.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum())
     AND ((aon.ligplaatsstatus <> 'Plaats ingetrokken' OR aon.ligplaatsstatus is NULL) AND
          (aon.standplaatsstatus <> 'Plaats ingetrokken' OR aon.standplaatsstatus is NULL) AND
          ((aon.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
@@ -214,18 +224,18 @@ CREATE VIEW verblijfsobjectpandactueel AS
     SELECT *
     FROM verblijfsobjectpand as vbop
   WHERE
-    vbop.beginDatumTijdvakGeldigheid <= now()
-    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= now())
-    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= now());
+    vbop.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectpandactueelbestaand;
 CREATE VIEW verblijfsobjectpandactueelbestaand AS
     SELECT *
     FROM verblijfsobjectpand as vbop
   WHERE
-    vbop.beginDatumTijdvakGeldigheid <= now()
-    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= now())
-    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= now())
+    vbop.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum())
     AND ((vbop.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vbop.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND
          vbop.verblijfsobjectStatus <> 'Verblijfsobject ten onrechte opgevoerd') OR
@@ -237,18 +247,18 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueel AS
     SELECT *
     FROM verblijfsobjectgebruiksdoel as vog
   WHERE
-    vog.beginDatumTijdvakGeldigheid <= now()
-    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= now())
-    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= now());
+    vog.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectgebruiksdoelactueelbestaand;
 CREATE VIEW verblijfsobjectgebruiksdoelactueelbestaand AS
     SELECT *
     FROM verblijfsobjectgebruiksdoel as vog
   WHERE
-    vog.beginDatumTijdvakGeldigheid <= now()
-    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= now())
-    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= now())
+    vog.beginDatumTijdvakGeldigheid <= extract_datum()
+    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum())
     AND ((vog.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vog.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND
           vog.verblijfsobjectStatus <> 'Verblijfsobject ten onrechte opgevoerd') OR


### PR DESCRIPTION
Om een bijzonder oud issue met de gemeentelijke indeling en actueelbestaand VIEWs op te lossen moet de stand datum gebruikt worden in plaats van NOW/LOCALTIMESTAMP.

Omdat de maandelijke extract van december in januari ook nog gebruikt kan worden, is het niet goed dat de gemeentelijke indeling van het nieuwe jaar vanaf januari gebruikt wordt. De nieuwe gemeentelijke indeling is in de maandelijkse extract van december immers nog niet verwerkt.

Wanneer #319 gemerged is kan de SQL voor de `provincie_gemeenteactueelbestaand` VIEW ook aangepast worden.

Zie ook:

 * https://github.com/nlextract/NLExtract/pull/158#issuecomment-168345951
 * #311