### PR TITLE
Correct begindatum for Vianen.

### DIFF
--- a/bag/db/data/gemeentelijke-indeling.xml
+++ b/bag/db/data/gemeentelijke-indeling.xml
@@ -8492,7 +8492,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
     </provincie>
@@ -9018,7 +9018,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
     </provincie>
@@ -9540,7 +9540,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
     </provincie>
@@ -10033,7 +10033,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -10524,7 +10524,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -11012,7 +11012,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -11482,7 +11482,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -11953,7 +11953,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -12422,7 +12422,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -12874,7 +12874,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -13319,7 +13319,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -13763,7 +13763,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -14195,7 +14195,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -14625,7 +14625,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -15045,7 +15045,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -15465,7 +15465,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>
@@ -15875,7 +15875,7 @@
       <gemeente code="355" naam="Zeist" begindatum="1970-01-01"/>
       <gemeente code="356" naam="Nieuwegein" begindatum="1971-07-01"/>
       <gemeente code="589" naam="Oudewater" begindatum="1970-01-01"/>
-      <gemeente code="620" naam="Vianen" begindatum="1970-01-01" einddatum="2019-01-01"/>
+      <gemeente code="620" naam="Vianen" begindatum="2002-01-01" einddatum="2019-01-01"/>
       <gemeente code="632" naam="Woerden" begindatum="1970-01-01"/>
       <gemeente code="736" naam="De Ronde Venen" begindatum="1989-01-01"/>
       <gemeente code="1581" naam="Utrechtse Heuvelrug" begindatum="2006-01-01"/>


### PR DESCRIPTION
In 2002 is de gemeente Vianen van provincie gewijzigd (van Zuid-Holland naar Utrecht).

De indelingen van 2003 en later gebruikten echter de begindatum van de gemeente in provincie Zuid-Holland ipv Utrecht.