### PR TITLE
Fix filter op einddatum in de views `actueel` en `actueelbestaand`

### DIFF
--- a/bagv2/etl/sql/create-views.sql
+++ b/bagv2/etl/sql/create-views.sql
@@ -187,7 +187,7 @@ CREATE VIEW provincie_gemeenteactueelbestaand AS
     FROM provincie_gemeente AS pg
   WHERE
     pg.begindatum <= extract_datum()
-    AND (pg.einddatum IS NULL OR pg.einddatum >= extract_datum());
+    AND (pg.einddatum IS NULL OR pg.einddatum > extract_datum());
 
 
 -- START RELATIE TABELLEN

--- a/bagv2/etl/sql/create-views.sql
+++ b/bagv2/etl/sql/create-views.sql
@@ -15,7 +15,7 @@ CREATE FUNCTION extract_datum()
 
 -- Feitelijk is de "acteel" definitie:
 -- begingeldigheid <= extract_datum()
---  AND (eindgeldigheid is NULL OR eindgeldigheid >= extract_datum())
+--  AND (eindgeldigheid is NULL OR eindgeldigheid > extract_datum())
 --  AND (tijdstipinactief is NULL)
 --  AND (tijdstipnietbaglv is NULL)
 
@@ -199,7 +199,7 @@ CREATE VIEW adresseerbaarobjectnevenadresactueel AS
   WHERE
     aon.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum());
+    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief > extract_datum());
 
 DROP VIEW IF EXISTS adresseerbaarobjectnevenadresactueelbestaand;
 CREATE VIEW adresseerbaarobjectnevenadresactueelbestaand AS
@@ -208,7 +208,7 @@ CREATE VIEW adresseerbaarobjectnevenadresactueelbestaand AS
   WHERE
     aon.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum())
+    AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief > extract_datum())
     AND ((aon.ligplaatsstatus <> 'Plaats ingetrokken' OR aon.ligplaatsstatus is NULL) AND
          (aon.standplaatsstatus <> 'Plaats ingetrokken' OR aon.standplaatsstatus is NULL) AND
          ((aon.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
@@ -226,7 +226,7 @@ CREATE VIEW verblijfsobjectpandactueel AS
   WHERE
     vbop.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum());
+    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief > extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectpandactueelbestaand;
 CREATE VIEW verblijfsobjectpandactueelbestaand AS
@@ -235,7 +235,7 @@ CREATE VIEW verblijfsobjectpandactueelbestaand AS
   WHERE
     vbop.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum())
+    AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief > extract_datum())
     AND ((vbop.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vbop.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND
          vbop.verblijfsobjectStatus <> 'Verblijfsobject ten onrechte opgevoerd') OR
@@ -249,7 +249,7 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueel AS
   WHERE
     vog.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum());
+    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief > extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectgebruiksdoelactueelbestaand;
 CREATE VIEW verblijfsobjectgebruiksdoelactueelbestaand AS
@@ -258,7 +258,7 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueelbestaand AS
   WHERE
     vog.beginDatumTijdvakGeldigheid <= extract_datum()
     AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid > extract_datum())
-    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum())
+    AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief > extract_datum())
     AND ((vog.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vog.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND
           vog.verblijfsobjectStatus <> 'Verblijfsobject ten onrechte opgevoerd') OR

--- a/bagv2/etl/sql/create-views.sql
+++ b/bagv2/etl/sql/create-views.sql
@@ -26,7 +26,7 @@ CREATE VIEW ligplaatsactueel AS
     SELECT * FROM ligplaats
     WHERE
       beginDatumTijdvakGeldigheid <= extract_datum()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
       AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS ligplaatsactueelbestaand;
@@ -34,7 +34,7 @@ CREATE VIEW ligplaatsactueelbestaand AS
     SELECT * FROM ligplaats
     WHERE
         beginDatumTijdvakGeldigheid <= extract_datum()
-        AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+        AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
         AND aanduidingrecordinactief is FALSE
         AND ligplaatsStatus <> 'Plaats ingetrokken'::ligplaatsStatus;
 
@@ -45,7 +45,7 @@ CREATE VIEW nummeraanduidingactueel AS
     FROM nummeraanduiding
     WHERE
       beginDatumTijdvakGeldigheid <= extract_datum()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
       AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS nummeraanduidingactueelbestaand;
@@ -53,7 +53,7 @@ CREATE VIEW nummeraanduidingactueelbestaand AS
     SELECT * FROM nummeraanduiding
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND nummeraanduidingStatus <> 'Naamgeving ingetrokken'::nummeraanduidingStatus;
 
@@ -63,7 +63,7 @@ CREATE VIEW openbareruimteactueel AS
     SELECT * FROM openbareruimte
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS openbareruimteactueelbestaand;
@@ -71,7 +71,7 @@ CREATE VIEW openbareruimteactueelbestaand AS
     SELECT * FROM openbareruimte
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND openbareruimteStatus <> 'Naamgeving ingetrokken'::openbareRuimteStatus;
 
@@ -81,7 +81,7 @@ CREATE VIEW pandactueel AS
     SELECT * FROM pand
     WHERE
       beginDatumTijdvakGeldigheid <= extract_datum()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
       AND aanduidingrecordinactief is FALSE 
       AND pand.geom_valid = TRUE;
 
@@ -90,7 +90,7 @@ CREATE VIEW pandactueelbestaand AS
     SELECT * FROM pand
     WHERE
      beginDatumTijdvakGeldigheid <= extract_datum()
-     AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+     AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
      AND aanduidingrecordinactief is FALSE
      AND (pandStatus <> 'Niet gerealiseerd pand'::pandStatus
      AND pandStatus <> 'Pand gesloopt'::pandStatus
@@ -104,7 +104,7 @@ CREATE VIEW standplaatsactueel AS
     SELECT * FROM standplaats
     WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS standplaatsactueelbestaand;
@@ -112,7 +112,7 @@ CREATE VIEW standplaatsactueelbestaand AS
     SELECT * FROM standplaats
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND standplaatsStatus <> 'Plaats ingetrokken'::standplaatsStatus;
 
@@ -122,7 +122,7 @@ CREATE VIEW verblijfsobjectactueel AS
     SELECT * FROM verblijfsobject
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 
@@ -131,7 +131,7 @@ CREATE VIEW verblijfsobjectactueelbestaand AS
     SELECT * FROM verblijfsobject
     WHERE
       beginDatumTijdvakGeldigheid <= extract_datum()
-      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+      AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
       AND aanduidingrecordinactief is FALSE
       AND (verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject'::verblijfsobjectStatus
       AND verblijfsobjectStatus  <> 'Verblijfsobject ingetrokken'::verblijfsobjectStatus
@@ -147,7 +147,7 @@ CREATE VIEW woonplaatsactueel AS
   SELECT * FROM woonplaats
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE;
 
 DROP VIEW IF EXISTS woonplaatsactueelbestaand;
@@ -155,7 +155,7 @@ CREATE VIEW woonplaatsactueelbestaand AS
   SELECT * FROM woonplaats
   WHERE
     beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (eindDatumTijdvakGeldigheid is NULL OR eindDatumTijdvakGeldigheid > extract_datum())
     AND aanduidingrecordinactief is FALSE
     AND woonplaatsStatus  <> 'Woonplaats ingetrokken'::woonplaatsStatus;
 
@@ -172,7 +172,7 @@ CREATE VIEW gemeente_woonplaatsactueelbestaand AS
     FROM gemeente_woonplaats as gw
   WHERE
     gw.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (gw.eindDatumTijdvakGeldigheid is NULL OR gw.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (gw.eindDatumTijdvakGeldigheid is NULL OR gw.eindDatumTijdvakGeldigheid > extract_datum())
     AND gw.status = 'definitief';
 
 DROP VIEW IF EXISTS provincie_gemeenteactueelbestaand;
@@ -198,7 +198,7 @@ CREATE VIEW adresseerbaarobjectnevenadresactueel AS
     FROM adresseerbaarobjectnevenadres as aon
   WHERE
     aon.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid > extract_datum())
     AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS adresseerbaarobjectnevenadresactueelbestaand;
@@ -207,7 +207,7 @@ CREATE VIEW adresseerbaarobjectnevenadresactueelbestaand AS
     FROM adresseerbaarobjectnevenadres as aon
   WHERE
     aon.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (aon.eindDatumTijdvakGeldigheid is NULL OR aon.eindDatumTijdvakGeldigheid > extract_datum())
     AND (aon.tijdstipinactief is NULL OR aon.tijdstipinactief >= extract_datum())
     AND ((aon.ligplaatsstatus <> 'Plaats ingetrokken' OR aon.ligplaatsstatus is NULL) AND
          (aon.standplaatsstatus <> 'Plaats ingetrokken' OR aon.standplaatsstatus is NULL) AND
@@ -225,7 +225,7 @@ CREATE VIEW verblijfsobjectpandactueel AS
     FROM verblijfsobjectpand as vbop
   WHERE
     vbop.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid > extract_datum())
     AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectpandactueelbestaand;
@@ -234,7 +234,7 @@ CREATE VIEW verblijfsobjectpandactueelbestaand AS
     FROM verblijfsobjectpand as vbop
   WHERE
     vbop.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vbop.eindDatumTijdvakGeldigheid is NULL OR vbop.eindDatumTijdvakGeldigheid > extract_datum())
     AND (vbop.tijdstipinactief is NULL OR vbop.tijdstipinactief >= extract_datum())
     AND ((vbop.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vbop.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND
@@ -248,7 +248,7 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueel AS
     FROM verblijfsobjectgebruiksdoel as vog
   WHERE
     vog.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid > extract_datum())
     AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum());
 
 DROP VIEW IF EXISTS verblijfsobjectgebruiksdoelactueelbestaand;
@@ -257,7 +257,7 @@ CREATE VIEW verblijfsobjectgebruiksdoelactueelbestaand AS
     FROM verblijfsobjectgebruiksdoel as vog
   WHERE
     vog.beginDatumTijdvakGeldigheid <= extract_datum()
-    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid >= extract_datum())
+    AND (vog.eindDatumTijdvakGeldigheid is NULL OR vog.eindDatumTijdvakGeldigheid > extract_datum())
     AND (vog.tijdstipinactief is NULL OR vog.tijdstipinactief >= extract_datum())
     AND ((vog.verblijfsobjectStatus <> 'Niet gerealiseerd verblijfsobject' AND
           vog.verblijfsobjectStatus <> 'Verblijfsobject ingetrokken' AND


### PR DESCRIPTION
WHERE-clauses in de `actueel` en `actueelbestaand` views zijn aangepast.

Het was: 
`eindDatumTijdvakGeldigheid >= extract_datum()` 
Het is nu:
`eindDatumTijdvakGeldigheid > extract_datum()`

De aangepaste clause zorgt ervoor dat objecten met `eindDatumTijdvakGeldigheid = extract_datum()` niet meer in de actueel(bestaand) views voorkomen.

Zelfde is toegepast op `einddatum` en`tijdstipinactief` in de view-definities voor de koppeltabellen.

Fixes #343.