### PR TITLE
Generate GFS name earlier and remove old file if it exists

### DIFF
--- a/stetlcomponents/gfspreparationfilter.py
+++ b/stetlcomponents/gfspreparationfilter.py
@@ -116,6 +116,16 @@ $featurecounts
 
         # TODO: consider using a Stetl chain for these steps
 
+        # Generate name of GFS file and remove an eventual old version
+        if self.output_gfs is not None:
+            gfs_path = self.output_gfs
+        else:
+            file_ext = os.path.splitext(input_gml)
+            gfs_path = file_ext[0] + '.gfs'
+
+        if os.path.exists(gfs_path):
+            os.remove(gfs_path)
+
         # Steps:
         # 1. Call ogrinfo and capture its output.
         log.info('calling ogrinfo')
@@ -136,12 +146,6 @@ $featurecounts
 
         # 5. Save the output_gfs.
         log.info('writing output GFS')
-
-        if self.output_gfs is not None:
-            gfs_path = self.output_gfs
-        else:
-            file_ext = os.path.splitext(input_gml)
-            gfs_path = file_ext[0] + '.gfs'
 
         with open(gfs_path, 'w') as f:
             f.write(result)


### PR DESCRIPTION
Small PR. When processing a small DKK dataset it appears that the old GFS file is being reused when OGRInfo is being executed. Therefor the name of the GFS file should be determined earlier, and if this file already exists, it should be removed.