### PR TITLE
add orderin adres_plus crosstab function

### DIFF
--- a/bagv2/etl/sql/adres/adres-tabel-plus.sql
+++ b/bagv2/etl/sql/adres/adres-tabel-plus.sql
@@ -812,6 +812,7 @@ from crosstab (
 FROM
   verblijfsobjectgebruiksdoelactueelbestaand VBOGBD
   group by   VBOGBD.identificatie ,   VBOGBD.gebruiksdoelverblijfsobject
+order by 1,2
  ',
 
   'select distinct gebruiksdoelverblijfsobject from   verblijfsobjectgebruiksdoelactueelbestaand order by 1'


### PR DESCRIPTION
Toevoegen van order by in de crosstab functie omdat anders vbo_id niet uniek wordt en het maken van de PK fout loopt