### PR TITLE
Fix documentation / dead links

### DIFF
--- a/bag/README.md
+++ b/bag/README.md
@@ -4,7 +4,7 @@ NLExtract BAG is onderdeel van de NLExtract tools voor het inlezen en verrijken 
 (Basisregistratie Adressen en Gebouwen) GML leveringen (via o.a. PDOK) in (voorlopig) een Postgres/Postgis database.
 
 De BAG Leveringsbestanden (totaal plm 1.2 GB .zip) worden iedere maand ververst en zijn te downloaden via deze  
-link: http://geodata.nationaalgeoregister.nl/inspireadressen/atom/inspireadressen.xml (Atom feed).
+link: https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml (Atom feed).
 
 NLExtract BAG biedt de volgende functionaliteiten:
 

--- a/bag/src/bagdownloadgui.py
+++ b/bag/src/bagdownloadgui.py
@@ -97,7 +97,7 @@ class BAGDownloadPanel(scrolled.ScrolledPanel):
         scrolled.ScrolledPanel.__init__(self, parent)
 
         self.parent = parent
-        self.atom_url = 'http://geodata.nationaalgeoregister.nl/inspireadressen/atom/inspireadressen.xml'
+        self.atom_url = 'https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml'
         self.extract_datum = 'ophalen...'
         self.extract_fsize = 'ophalen...'
         self.extract_url = 'ophalen...'

--- a/doc/source/algemeen.rst
+++ b/doc/source/algemeen.rst
@@ -104,6 +104,6 @@ Daartoe zijn in 2014 in NLExtract drie nieuwe NLExtract Services opgestart.
 
 In 2020 zijn de NLExtract Downloads te vinden via https://geotoko.nl.
 Veel informatie en voorbeeldbestanden vind je via https://geocatalogus.nl.
-De "Ga Naar Bron" links verwijzen nar geotoko.nl.
+De "Ga Naar Bron" links verwijzen naar geotoko.nl.
 
 Lees in het volgende hoofdstuk :ref:`services` meer hierover.

--- a/doc/source/bagextract.rst
+++ b/doc/source/bagextract.rst
@@ -17,7 +17,7 @@ BAG Bronbestanden downloaden
 ----------------------------
 
 De BAG Leveringsbestanden (totaal plm 1.5 GB .zip) worden iedere maand ververst en zijn te downloaden via deze
-PDOK link: https://geodata.nationaalgeoregister.nl/inspireadressen/atom/inspireadressen.xml (Atom feed).
+PDOK link: https://service.pdok.nl/kadaster/adressen/atom/v1_0/adressen.xml (Atom feed).
 Als je wilt testen met een kleiner bestand kun je via https://data.nlextract.nl/bag/bron/BAG_Amstelveen_2011feb01.zip
 ook de "BAG Amstelveen" (5.6 MB) downloaden. Let wel dat de bestandsstructuur van de Amstelveen-levering afwijkt van de tegenwoordige BAG-leveringen.
 
@@ -70,7 +70,7 @@ Instructies hieronder zijn voor Ubuntu 18.04. Bij andere distributies zal het en
 
 - Bronbestanden downloaden op de achtergrond (duurt wat langer) ::
     
-    $ wget https://geodata.nationaalgeoregister.nl/inspireadressen/extract/inspireadressen.zip &
+    $ wget https://service.pdok.nl/kadaster/adressen/atom/v1_0/downloads/lvbag-extract-nl.zip &
     
 - Bag-extract downloaden (pas eventueel versie aan) en uitpakken ::
     
@@ -334,6 +334,4 @@ Bij foutmeldingen als *COPY failed for table "nummeraanduiding": ERROR: value to
 heeft je "bag" database niet de **UTF8 character encoding** (zie boven). Check bij aanmaken, vooral op Windows,
 of je DB de character-encoding UTF8 heeft. Is later aan te passen.
 Zie ook `dit issue <https://github.com/nlextract/NLExtract/issues/217>`_.
-
-Zie https://docs.kademo.nl/project/bagextract.html voor een installatie voorbeeld.
 


### PR DESCRIPTION
Ik las de documentatie en kwam dead-links tegen, de open data distributie is nogal veranderlijk. Zie https://geoforum.nl/t/oude-url-s-inspire-adressen-uitgefaseerd/7325/1

Misschien ook een idee om de hele `bag` (v1)-directory op te ruimen, net als `ddkv3`. Want die bestanden/urls zijn er niet meer.